### PR TITLE
Handle when all crosswords for a publication aren't available

### DIFF
--- a/scripts/11-download-puzzles.py
+++ b/scripts/11-download-puzzles.py
@@ -146,7 +146,7 @@ def download_puzzles(outf, puzsrc, pubid, dates_to_get):
 #        sources_tsv += xd_sources_row(fn, url, todaystr)
         time.sleep(2)
 
-    return max(actually_gotten)
+    return max(actually_gotten) if actually_gotten else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In cases where it is empty, max() will result in an Exception, since it
expects a sequence containing at least one item.

Without this, if an entire publication fails to download any crosswords, the crosswords will fail to download for all of the publications after it.