### PR TITLE
Drop pytest-runner and "setup.py test" support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To execute everything for packaging and testing:
 
 To just run unit tests:
 
-        $ python setup.py test
+        $ python -m pytest
 
 ## code style
 

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,6 @@ setup(
     license='MIT',
 
     # Testing
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
-
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,6 @@
 envlist = py27
 
 [testenv]
-basepython = python2.7
-
-
 # These run in order. unit tests first, then linting. It bails on the first
 # problem it finds.
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py27
 # These run in order. unit tests first, then linting. It bails on the first
 # problem it finds.
 commands =
-	{envpython} setup.py test
+	{envpython} -m pytest {posargs}
     # check-manifest --ignore tox.ini,tests*
     python setup.py check -m -r -s
     flake8 .


### PR DESCRIPTION
First, removes `basepython` from `tox.ini`, which seems to be necessary for testing Pythons other than `py27` with `tox`.

Then, removes `pytest-runner` from `setup_requires`, and removes `test_requires`, which is deprecated and only useful with `setup.py test`. Adjusts `tox.ini` to use `pytest` instead of `setup.py` test.

The `pytest-runner` package has been deprecated upstream for some time, and the project is now archived:
https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice

Furthermore, the "setup.py test" command was removed in setuptools 72: https://github.com/pypa/setuptools/blob/v75.8.0/NEWS.rst#v7200

After this PR, I can run `tox -e py313`, `tox -e py39`, etc. successfully, with only the two test failures reported in https://github.com/century-arcade/xd/issues/72.