### PR TITLE
Script died when there was a warn() call.

### DIFF
--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -3,6 +3,7 @@
 import sys
 import string
 import urllib.parse
+import warnings
 
 # pip install crossword puzpy
 
@@ -283,10 +284,10 @@ def parse_puz(contents, filename):
                         if ch in rebus_shorthands:
                             cellch = ch
                             rebus_shorthands.remove(ch)
-                            warn("%s: unknown grid character '%s', assuming rebus of itself" % (filename, ch))
+                            warnings.warn("%s: unknown grid character '%s', assuming rebus of itself" % (filename, ch))
                         else:
                             cellch = rebus_shorthands.pop()
-                            warn("%s: unknown grid character '%s', assuming rebus (as '%s')" % (filename, ch, cellch))
+                            warnings.warn("%s: unknown grid character '%s', assuming rebus (as '%s')" % (filename, ch, cellch))
 
                         xd.set_header("Rebus", xd.get_header("Rebus") + " %s=%s" % (cellch, ch))
 


### PR DESCRIPTION
This was because warnings was not imported.
This caused a failure to convert this puzzle: https://www.xwordinfo.com/Crossword?date=12/29/2024 since it has -'s in it.

Traceback (most recent call last):
  File "/src/xd/puz2xd-standalone.py", line 331, in <module>
    main(fn)
  File "/src/xd/puz2xd-standalone.py", line 326, in main
    xd = parse_puz(open(fn, mode='rb').read(), fn)
  File "/src/xd/puz2xd-standalone.py", line 289, in parse_puz
    warn("%s: unknown grid character '%s', assuming rebus (as '%s')" % (filename, ch, cellch))
NameError: name 'warn' is not defined

Now the script now warns:
/src/xd/puz2xd-standalone.py:290: UserWarning: nyt/NY Times - 20241229 - Multi-Hyphenates.puz: unknown grid character '-', assuming rebus (as '1')
  warnings.warn("%s: unknown grid character '%s', assuming rebus (as '%s')" % (filename, ch, cellch))