### PR TITLE
Fix broken tests in test_xdfile.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# Project overview
+xd is a crossword puzzle processing pipeline. It defines the `.xd` plain-text format and provides tools to convert from other formats (puz, ipuz, XML, JSON) into `.xd`.
+
+# Key directories
+- `xdfile/` — Main Python package: parser, converter modules, utilities
+- `xdfile/tests/` — pytest tests
+- `crossword/` — Local fork of the `crossword` Python library (used by puz2xd)
+- `scripts/` — Utility scripts for processing and web serving
+- `doc/` — Documentation including `xd-format.md` (the format spec)
+
+# Important files
+- `xdfile/xdfile.py` — Core `xdfile` class: parse_xd(), to_unicode(), grid/clue iteration
+- `xdfile/utils.py` — Utilities: parse_pathname(), parse_date_from_filename(), file I/O
+- `xdfile/puz2xd.py` — .puz → .xd converter (module version, used as library)
+- `puz2xd-standalone.py` — .puz → .xd converter (standalone script, duplicates decode/xdfile logic)
+- `xdfile/__init__.py` — Just `from .xdfile import *`
+
+# .xd format structure
+Sections separated by double blank lines:
+1. Headers (key: value pairs)
+2. Grid (rows of characters, `#` = block)
+3. Clues (`A1. Clue text ~ ANSWER`)
+4. Notes (optional)
+
+# Architecture notes
+- `puz2xd-standalone.py` duplicates the `xdfile` class and `decode()` from `xdfile/puz2xd.py` — changes to one should be mirrored in the other
+- The `decode()` function handles character encoding cleanup for .puz files. It chains: byte replacements → urllib.parse.unquote → html.unescape → invalid entity cleanup
+- `to_unicode()` automatically inserts blank lines between clue direction changes (A→D), so `parse_xd()` should NOT insert clue breaks for blank lines between directions
+- `append_clue_break()` adds `(('', ''), '', '')` sentinel entries to the clues list — used as separators, not real clues
+
+# Testing
+```
+# Needs venv with dependencies
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install pytest
+pytest xdfile/tests/
+```

--- a/xdfile/tests/test_xdfile.py
+++ b/xdfile/tests/test_xdfile.py
@@ -2,25 +2,26 @@
 
 import datetime
 
-import xdfile as xdfile
+from xdfile.utils import parse_pathname, parse_date_from_filename, parse_pubid
 from xdfile.xdfile import xdfile as XDFile
 
 test_selection = 'nyt1955-01-01.xd'
 
 
 def test_filename():
-    fname = xdfile.get_base_filename(test_selection)
-    assert fname == 'nyt1955-01-01'
-    # xobject = xdfile.xdfile(xd_contents=testfile, xd_filename='derp')
+    base = parse_pathname(test_selection).base
+    assert base == 'nyt1955-01-01'
 
 
 def test_parse_date():
+    date = parse_date_from_filename(test_selection)
+    assert isinstance(date, datetime.date)
+    assert date.strftime('%a %b %d %Y') == 'Sat Jan 01 1955'
 
-    date = xdfile.parse_date_from_filename(test_selection)
-    assert isinstance(date, tuple)
-    assert date[0] == 'nyt'
-    assert isinstance(date[1], datetime.date)
-    assert date[1].strftime('%a %b %d %Y') == 'Sat Jan 01 1955'
+
+def test_parse_pubid():
+    pubid = parse_pubid(test_selection)
+    assert pubid == 'nyt'
 
 
 SAMPLE_XD = """\


### PR DESCRIPTION
## Summary
- Updated `test_xdfile.py` to use actual API functions from `xdfile.utils` instead of non-existent `xdfile.get_base_filename()` 
- Fixed `test_parse_date` to match actual `parse_date_from_filename()` return type (date, not tuple)
- Added `test_parse_pubid` to separately test publisher ID extraction

Fixes #72

## Test plan
- [x] All 5 tests pass (`pytest xdfile/tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)