### PR TITLE
Fix download pipeline and pin dependency versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,12 @@ S3_WWW=s3://xd.saul.pw
 
 all: analyze gridmatches website
 
-pipeline: setup import analyze gridmatches commit
+pipeline: setup deps import analyze gridmatches commit
 
 netlify: setup-gxd analyze website
+
+deps:
+	pip install --upgrade -r requirements.txt
 
 setup: setup-gxd setup-src
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-crossword
-xword-dl
-puzpy
+crossword==0.1.2
+xword-dl==2025.10.14
+puzpy==0.2.6
 
 # xdfile deps
-lxml            # for ccxml2xd, uxml2xd, xwordinfo2xd
-boto3 >= 1.3.1  # for cloud.py
-botocore        # for boto3?
-cssselect       # do not see it imported anywhere
+lxml==6.0.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
+boto3>=1.26.66    # for cloud.py
+botocore>=1.29.66 # for boto3?
+cssselect==1.2.0  # do not see it imported anywhere
 legacy-cgi; python_version >= '3.13'

--- a/scripts/11-download-puzzles.py
+++ b/scripts/11-download-puzzles.py
@@ -20,7 +20,7 @@ from xword_dl import by_keyword
 
 # For supported outlets, use xword-dl to download a .puz file of the most recent puzzle.
 # this is the xd pubid
-XWORDDL_OUTLETS = ['lat', 'tny', 'up', 'usa', 'nw', 'atl', 'nyt']
+XWORDDL_OUTLETS = ['lat', 'tny', 'up', 'usa', 'nw', 'atl', 'nyt', 'wap']
 # wsj, wap do not support selection by date
 # wap is not a daily but does have its pub date in the 'copyright'
 # field of the .puz

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -325,6 +325,9 @@ class AttrDict(dict):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
 
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))
+
 #class AttrDict(dict):
 #    __getattr__ = dict.__getitem__
 #    __setattr__ = dict.__setitem__


### PR DESCRIPTION
## Summary
- **Fix AttrDict hashability**: Make `AttrDict` hashable so it can be used in sets (fixes pipeline crash)
- **Add Washington Post**: Add WaPo to the xword-dl download sources in `11-download-puzzles.py`
- **Pin dependency versions**: Pin exact versions for core puzzle deps (crossword, xword-dl, puzpy, lxml, cssselect) in `requirements.txt`
- **Auto-upgrade in pipeline**: Add `deps` Makefile target that runs `pip install --upgrade` on each pipeline run, so version bumps are picked up automatically

## Test plan
- [ ] `pip install -r requirements.txt` succeeds
- [ ] `make deps` installs/upgrades as needed
- [ ] `make pipeline` runs end-to-end with new deps target

🤖 Generated with [Claude Code](https://claude.com/claude-code)