### PR TITLE
Change download step to use puzzle date in filename, not today's date

### DIFF
--- a/scripts/11-download-puzzles.py
+++ b/scripts/11-download-puzzles.py
@@ -37,17 +37,21 @@ def download_puzzles(outf, puzsrc, pubid, date, xwordid):
     fn = "%s.%s" % (xdid, puzsrc.ext)
 
     if pubid in XWORDDL_OUTLETS:
+        filename_t = pubid + "%Y-%m-%d"  # wap2026-04-01
         try:
             # `content` is always a a puz.Puz object
             log("downloading '%s' using xword-dl" % (fn))
-            content, filename = by_keyword(xwordid, date=date.strftime("%Y-%m-%d"))
+            content, filename = by_keyword(xwordid, date=date.strftime("%Y-%m-%d"), filename=filename_t)
         except Exception as e:
             try:
                 log("downloading date %s using xword-dl failed; downloading latest" % date.strftime("%Y-%m-%d"))
-                content, filename = by_keyword(xwordid)
+                content, filename = by_keyword(xwordid, filename=filename_t)
             except Exception as e:
                 error('xword-dl error %s: %s' % (str(e), xdid))
                 return False
+        if filename != fn:
+            log("downloaded '%s' using xword-dl" % filename)
+            fn = filename
     else:
         try:
             log("downloading '%s' from url %s " % (fn, url))


### PR DESCRIPTION
Weekly puzzles (such as the wap sunday) are re-downloaded daily, saving the file each day with today's date, which causes it to be converted and imported as if it were new. So we end up with the same puzzle with multiple filenames (one for every day of the week).  Fix is to let xword-dl pick the filename since it embeds the actual publication date. Shouldn't affect anything other than allowing the import pipeline downstream to notice that we've already seen the file and skip it.

Closes issue #93 