### PR TITLE
Add CI github action for flake8 and pytest

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+[flake8]
+# These are options specific to the way flake8 runs.
+# http://flake8.readthedocs.org/en/latest/config.html
+# TODO: E501 is long lines. ignore for now...
+ignore = E501
+max-line-length = 10000
+select = E,W,F
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    *.egg,
+    build,
+    data,
+    tests,
+    # vendored library, ignore
+    crossword,

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -32,9 +32,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude crossword
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude crossword
     - name: Test with pytest
       run: |
         pytest

--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from collections import namedtuple
 import sys
 import string
 import html
@@ -281,7 +282,7 @@ def parse_puz(contents, filename):
 
     # check for circles and record them if they exist
     circles = []
-    if b"GEXT" in puzobj.extensions: 
+    if b"GEXT" in puzobj.extensions:
         for i, c in enumerate(puzobj.extensions[b"GEXT"]):
             if c == 0x80: circles.append(i)
     if circles: xd.set_header("Special", "circle")
@@ -347,6 +348,16 @@ def parse_puz(contents, filename):
         raise Exception("Clue doesn't match grid: %s" % e)
 
     return xd
+
+
+def parse_pathname(path):
+    # Fix to proper split names like file.xml.1
+    ext = os.extsep + os.extsep.join(os.path.basename(path).split(os.extsep)[1:])
+    path, fn = os.path.split(path)
+    ext = ext if fn else ''
+    base = os.path.splitext(fn)[0]
+    nt = namedtuple('Pathname', 'path base ext filename')
+    return nt(path=path, base=base, ext=ext, filename=fn)
 
 
 def main(fn):

--- a/queries/remix.py
+++ b/queries/remix.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from xdfile.utils import get_args, open_output, find_files, log, debug, info, error, get_log, COLUMN_SEPARATOR, EOL
-from xdfile.utils import parse_tsv, progress, parse_pathname
+from xdfile.utils import parse_tsv, progress, parse_pathname, iso8601
 from xdfile import corpus, xdfile, BLOCK_CHAR
 
 
@@ -94,7 +94,7 @@ def mutate(xd, words, chance=1):
 
 def load_clues():
     ret = {} # ["pubid"] = { ["ANSWER"] = { ["simplified clue text"] = set(fullclues) } }
-    for r in parse_tsv(file("clues.tsv").read(), "AnswerClue"):
+    for r in parse_tsv("clues.tsv", "AnswerClue"):
         try:
             pubid, dt, answer, clue = r
         except Exception as e:

--- a/queries/xdstats.py
+++ b/queries/xdstats.py
@@ -23,7 +23,7 @@ def get_blank_grid(xd):
 
 
 def find_grid(fn):
-    needle = get_blank_grid(xdfile(file(fn).read()))
+    needle = get_blank_grid(xdfile(open(fn).read()))
 
     return [xd for xd in xdfile.corpus() if needle == get_blank_grid(xd)]
 
@@ -80,9 +80,9 @@ if __name__ == "__main__":
     all_words = get_all_words()
     print("%d unique words.  most used words:" % len(all_words))
     for word, num_uses in sorted(all_words.items(), key=lambda x: -x[1])[0:10]:
-        print num_uses, word
+        print(num_uses, word)
 
-    print
+    print()
     groups = {"small": 0, "medium":0, "large":0, "huge":0}
     for xd in xdfile.corpus():
         if xd.width() < 14 and xd.height() < 14:
@@ -92,11 +92,10 @@ if __name__ == "__main__":
         elif xd.height() < 25 and xd.height() < 25:
             groups["large"] += 1
         else:
-            print xd
+            print(xd)
             groups["huge"] += 1
 
     for k, v in groups.items():
         print("%s %s" % (k,v))
 
-    print
-
+    print()

--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -13,7 +13,7 @@ import zipfile
 
 from xdfile import IncompletePuzzleParse
 
-from xdfile.utils import log, debug, error
+from xdfile.utils import log, debug, warn, error
 from xdfile.utils import find_files_with_time, parse_pathname, replace_ext, strip_toplevel
 from xdfile.utils import args_parser, get_args, parse_tsv_data, iso8601, open_output, progress
 

--- a/scripts/21-clean-metadata.py
+++ b/scripts/21-clean-metadata.py
@@ -133,8 +133,8 @@ def clean_headers(xd):
                 dt = d.strftime("%Y-%m-%d")
         except Exception as e:
             utils.error(str(e))
-            if args.debug:
-                raise
+            #if args.debug:
+                #raise
 
     ## try getting Date from copyright
     if not dt:

--- a/scripts/httpxd.py
+++ b/scripts/httpxd.py
@@ -38,7 +38,7 @@ class httpxd(object):
     @cherrypy.expose
     def style_css(self):
         cherrypy.response.headers['Content-Type'] = 'text/css'
-        return file("src/style.css").read()
+        return open("src/style.css").read()
 
     @staticmethod
     def xd_from_grid(grid):

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -516,7 +516,7 @@ class OutputDirectory:
 
 def open_output(fnout=None):
     assert g_args
-    global g_logfp
+    # global g_logfp
 
     if not fnout:
         fnout = g_args.output


### PR DESCRIPTION
Only accept this if you want it, but I figured it might be nice to have pytest and flake8 run on every merge.  It only selects a subset of the highest-sev flake8 error codes, which ended up needing ~5 code changes to get passing.  Also note that this project effectively requires python 3.10 due to the pinned dep on `xword-dl==2025.10.14` which is python>=3.10. 