### PR TITLE
perf improvement for import: caching of regex and receipts files

### DIFF
--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -44,15 +44,21 @@ def get_publication(xd):
     return sorted(matching_pubs)[0][1]
 
 # some regex heuristics for shelving
+_pubregex_cache = None
+
 def find_pubid(rowstr):
     '''rowstr is a concatentation of all metadata fields
     Returns None if file not exist or empty
     '''
-    try:
-        regexes = utils.parse_tsv_data(open(PUBREGEX_TSV, 'r').read())
-    except FileNotFoundError:
-        utils.error("File not exists: %s" % PUBREGEX_TSV, severity='WARNING')
-        return None
+    global _pubregex_cache
+    if _pubregex_cache is None:
+        try:
+            _pubregex_cache = list(utils.parse_tsv_data(open(PUBREGEX_TSV, 'r').read()))
+        except FileNotFoundError:
+            utils.error("File not exists: %s" % PUBREGEX_TSV, severity='WARNING')
+            _pubregex_cache = []
+
+    regexes = _pubregex_cache
 
     matching = set()
     for r in regexes:

--- a/xdfile/metadatabase.py
+++ b/xdfile/metadatabase.py
@@ -208,12 +208,17 @@ def xd_receipts_row(CaptureTime="", ReceivedTime="", ExternalSource="", Internal
     ]) + EOL
 
 
-def check_already_received(ExternalSource, SourceFilename):
-    ret = []
+@utils.memoize
+def _receipts_by_source():
+    d = {}
     for r in read_rows('gxd/receipts'):
-        if r.ExternalSource == ExternalSource and r.SourceFilename == SourceFilename:
-            ret.append(r)
-    return ret
+        key = (r.ExternalSource, r.SourceFilename)
+        d.setdefault(key, []).append(r)
+    return d
+
+
+def check_already_received(ExternalSource, SourceFilename):
+    return _receipts_by_source().get((ExternalSource, SourceFilename), [])
 
 
 def xd_sources_row(SourceFilename, ExternalSource, DownloadTime):


### PR DESCRIPTION
Caches pubregex and receipts files during import to avoid reading them on each file. Looks like there was already some caching in the project, so I just extended it to cover these paths as well.

Before (WSJ import, interrupted after 50 imported files):
```
     2 sources.tsv
  1000 sources.tsv 91231.puz
    50 bwh/WSJ/wsj151102.puz Traceback (most recent call last):
    KeyboardInterrupt

real    1m5.222s
user    0m0.015s
sys     0m0.030s
```
.77 files/sec

After (WSJ import, all 1000 files):
```
     2 sources.tsv
  1000 sources.tsv 91231.puz
   998 bwh/WSJ/wsj980814.puz
real    0m10.124s
user    0m0.000s
sys     0m0.015s
```
98.8 files/sec

128x faster. makes a difference!
