### PR TITLE
Bug fixes in conversion scripts

### DIFF
--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -29,6 +29,7 @@ NON_ANSWER_CHARS = [BLOCK_CHAR, OPEN_CHAR]  # UNKNOWN_CHAR is a wildcard answer 
 def decode(s):
     s = s.replace('\x92', "'")
     s = s.replace('\xc2\x92', "'")
+    s = s.replace('\xc2\xa0', ' ')  # UTF-8 NBSP double-decoded as latin-1
     s = s.replace('\xc3\x82',"")
     s = s.replace('\xc3\xa8',"è") # +A5. Crème de la crème ~ ELITE
     s = s.replace('\xe0','à') # -A49. Do the seemingly impossible, à la Jesus ~ WALKONWATER
@@ -46,6 +47,8 @@ def decode(s):
     # Remove spurious semicolons from invalid HTML entity refs
     # (e.g. html2text converts "B&O" to "B&O;")
     s = re.sub(r'&([A-Za-z0-9]+);', r'&\1', s)
+    # Collapse any run of whitespace to a single space (clue text shouldn't have tabs or multi-space runs)
+    s = re.sub(r'\s+', ' ', s)
     return s
 
 

--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -236,13 +236,13 @@ def parse_puz(contents, filename):
 
     xd = xdfile()
 
-    xd.set_header("Author", puzobj.author)
-    xd.set_header("Copyright", puzobj.copyright)
-    xd.set_header("Notes", puzobj.notes)
-    xd.set_header("Postscript", "".join(x for x in puzobj.postscript if ord(x) >= ord(' ')))
+    xd.set_header("Author", decode(puzobj.author))
+    xd.set_header("Copyright", decode(puzobj.copyright))
+    xd.set_header("Notes", decode(puzobj.notes))
+    #xd.set_header("Postscript", "".join(x for x in puzobj.postscript if ord(x) >= ord(' ')))
     xd.set_header("Preamble", puzobj.preamble)
 
-    xd.set_header("Title", puzobj.title)
+    xd.set_header("Title", decode(puzobj.title))
 
     # Look for a date from filename
     base_filename = os.path.basename(filename) # Get just the filename part, e.g., "Publisher - 20250101.puz"
@@ -281,7 +281,7 @@ def parse_puz(contents, filename):
 
     # check for circles and record them if they exist
     circles = []
-    if b"GEXT" in puzobj.extensions: 
+    if b"GEXT" in puzobj.extensions:
         for i, c in enumerate(puzobj.extensions[b"GEXT"]):
             if c == 0x80: circles.append(i)
     if circles: xd.set_header("Special", "circle")

--- a/xdfile/puz2xd.py
+++ b/xdfile/puz2xd.py
@@ -24,6 +24,7 @@ def reparse_date(s):
 def decode(s):
     s = s.replace('\x92', "'")
     s = s.replace('\xc2\x92', "'")
+    s = s.replace('\xc2\xa0', ' ')  # UTF-8 NBSP double-decoded as latin-1
     s = s.replace('\xc3\x82',"")
     s = s.replace('\xc3\xa8',"è") # +A5. Crème de la crème ~ ELITE
     s = s.replace('\xe0','à') # -A49. Do the seemingly impossible, à la Jesus ~ WALKONWATER
@@ -41,6 +42,8 @@ def decode(s):
     # Remove spurious semicolons from invalid HTML entity refs
     # (e.g. html2text converts "B&O" to "B&O;")
     s = re.sub(r'&([A-Za-z0-9]+);', r'&\1', s)
+    # Collapse any run of whitespace to a single space (clue text shouldn't have tabs or multi-space runs)
+    s = re.sub(r'\s+', ' ', s)
     return s
 
 

--- a/xdfile/puz2xd.py
+++ b/xdfile/puz2xd.py
@@ -64,13 +64,11 @@ def parse_puz(contents, filename):
 
     xd = xdfile.xdfile('', filename)
 
-    xd.set_header("Author", puzobj.author)
-    xd.set_header("Copyright", puzobj.copyright)
-    xd.set_header("Notes", puzobj.notes)
-    xd.set_header("Postscript", "".join(x for x in puzobj.postscript if ord(x) >= ord(' ')))
-    xd.set_header("Preamble", puzobj.preamble)
+    xd.set_header("Author", decode(puzobj.author))
+    xd.set_header("Copyright", decode(puzobj.copyright))
+    xd.set_header("Notes", decode(puzobj.notes))
 
-    xd.set_header("Title", puzobj.title)
+    xd.set_header("Title", decode(puzobj.title))
 
     used_rebuses = {}  # [puz_rebus_gridvalue_as_string] -> our_rebus_gridvalue
     rebus = {}  # [our_rebus_gridvalue] -> full_cell
@@ -92,7 +90,7 @@ def parse_puz(contents, filename):
 
     # check for circles and record them if they exist
     circles = []
-    if b"GEXT" in puzobj.extensions: 
+    if b"GEXT" in puzobj.extensions:
         for i, c in enumerate(puzobj.extensions[b"GEXT"]):
             if c == 0x80: circles.append(i)
     if circles: xd.set_header("Special", "circle")


### PR DESCRIPTION
some random fixes in the conversion scripts:
- apply character decoding to puz title, author, copyright, as well as clues. Picks up a bunch of fixes to html entities and the like.
- replace \t with ' '. Not sure why but a number of the .puz files in bwh-2015.tgz have \t characters in clues. Seemingly unintentional.
- reduce runs of whitespace to a single ' '. Maybe a little risky/controversial, but there are weird double-spaces all over the place, seemingly not meaningful or intended. Possible error in litzing.