### PR TITLE
Makefile website failing due to too many xd args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ PUB_DIR=pub
 NOW=$(shell date +"%Y%m%d-%H%M%S")
 YEAR=$(shell date +"%Y")
 WWWZIP=/tmp/${NOW}-www.zip
-RECENT_XDS=$(shell git -C ${GXD_DIR} log --pretty="format:" --since="30 days ago" --name-only | sort | uniq)
-TODAY_XDS=$(shell git -C ${GXD_DIR} log --pretty="format:" --since="1 days ago" --name-only | sort | uniq)
 
 S3_REGION=us-west-2
 S3_WWW=s3://xd.saul.pw
@@ -51,14 +49,16 @@ analyze:
 	scripts/26-mkzip-clues.py -c ${GXD_DIR} -o ${WWW_DIR}/xd-clues.zip
 	scripts/29-mkzip-metadata.py -c ${GXD_DIR} -o ${WWW_DIR}/xd-metadata.zip
 
+website: RECENT_XDS_FILE=/tmp/${NOW}-recent-xds.txt
 website: website-static
 	mkdir -p ${WWW_DIR}/pub/gxd
 	zip -q -r ${WWW_DIR}/xd-puzzles.zip `cat ${GXD_DIR}/pubs.txt`
+	git -C ${GXD_DIR} log --pretty="format:" --since="30 days ago" --name-only | sort -u > ${RECENT_XDS_FILE}
 	scripts/37-pubyear-svg.py -o ${WWW_DIR}/ # /pub/ index
 	scripts/33-mkwww-words.py -c ${GXD_DIR} -o ${WWW_DIR}/ # /pub/word/<ANSWER>
-	scripts/34-mkwww-clues.py -c ${GXD_DIR} -o ${WWW_DIR}/ ${RECENT_XDS} # /pub/clue/<boiledclue>
+	scripts/34-mkwww-clues.py -c ${GXD_DIR} -o ${WWW_DIR}/ --inputs-from ${RECENT_XDS_FILE} # /pub/clue/<boiledclue>
 	scripts/35-mkwww-diffs.py -c ${GXD_DIR} -o ${WWW_DIR}/ # /pub/<xdid>
-	scripts/36-mkwww-deepclues.py -c ${GXD_DIR} -o ${WWW_DIR}/ ${RECENT_XDS} # /pub/clue/<xdid>
+	scripts/36-mkwww-deepclues.py -c ${GXD_DIR} -o ${WWW_DIR}/ --inputs-from ${RECENT_XDS_FILE} # /pub/clue/<xdid>
 
 website-static:
 	mkdir -p ${WWW_DIR}

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -125,12 +125,19 @@ def get_args(desc="", parser=None):
         parser = args_parser(desc)
 
     parser.add_argument('inputs', nargs='*', help='toplevel input(s)')
+    parser.add_argument('--inputs-from', dest='inputs_from', default=None,
+                        help='read additional input paths from FILE (one per line); bypasses shell ARG_MAX limits')
     parser.add_argument('-o', '--output', dest='output', action='store')
     parser.add_argument('-q', '--quiet', dest='verbose', action='store_const', const=-1, default=0)
     parser.add_argument('-v', '--verbose', dest='verbose', action='count', default=0)
     parser.add_argument('-d', '--debug', dest='debug', action='store_true', default=False, help='abort on exception')
     parser.add_argument('-c', '--corpus', dest='corpusdir', default='crosswords', help='corpus source')
     g_args = parser.parse_args()
+
+    if g_args.inputs_from:
+        with open(g_args.inputs_from) as f:
+            extra = [ln.strip() for ln in f if ln.strip()]
+        g_args.inputs = list(g_args.inputs) + extra
 
     return g_args
 


### PR DESCRIPTION
The website Makefile target gets a list of xd files that have changed in the last 30 days and passes it on the command line to scripts/34-mkwww-clues.py. if there were a lot of new files (for example due to batch importing), this exceeds linux's max command-line and fails with an error.  Proposed fix here is to add a --inputs-from argument argument that allows inputs to be passed in a file. 