### PR TITLE
set of changes to import scripts to make reimporting a little easier

### DIFF
--- a/PROCESSING.md
+++ b/PROCESSING.md
@@ -1,6 +1,9 @@
 ## How to process big puzzle archive (like bwh.zip)
 
-        rm -rf bwh-zips/ && mkdir bwh-zips
+        # 90-split-archive.py reads files from the positional input path (bwh/).
+        # --source is only a metadata label written into sources.tsv; it is not an input file path.
+        rm -rf bwh/ bwh-zips/ && mkdir bwh/ bwh-zips/
+        tar -xzf ~/Downloads/bwh-2015.tgz -C bwh/
         ./scripts/90-split-archive.py -o bwh-zips/ --source bwh-2015.tgz bwh/
         ./scripts/18-convert2xd.py -o gxd/ bwh-zips/up.zip
 
@@ -24,6 +27,13 @@
         ../scripts/55-lint.sh
         cd .. && ./scripts/19b-receipts-tsv.sh
         ./scripts/48-stats.sh
+
+## publications.tsv maintenance
+
+`gxd/publications.tsv` is maintained manually (or by a separate curated process).
+Import scripts such as `scripts/18-convert2xd.py` and `scripts/19-reshelve.py` do not automatically add/update publication rows.
+
+When introducing a new publication/pubid, add the row to `gxd/publications.tsv` before running imports for that pubid.
 
 ## How to check receipts.tsv for duplicate values
 

--- a/scripts/10-manual.sh
+++ b/scripts/10-manual.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 #
-# Usage: <$0> <branch to work on> <zip file to process> <source name>
+# Usage: <$0> <branch to work on> <zip file to process> <external source> [internal source]
 
 source scripts/helpers.sh
 
 BRANCH=$1
 INPUT=$2
 EXTSRC=$3
+INTSRC=$4
 
 set -e
 
@@ -25,7 +26,11 @@ cd $GXD
 git branch -f $BRANCH && git checkout $BRANCH . && git clean -df
 cd ..
 
-$python scripts/18-convert2xd.py ${DEBUG} $INPUT -o $GXD/ --extsrc "$EXTSRC"
+if [ -n "$INTSRC" ]; then
+	$python scripts/18-convert2xd.py ${DEBUG} "$INPUT" -o "$GXD/" --extsrc "$EXTSRC" --intsrc "$INTSRC"
+else
+	$python scripts/18-convert2xd.py ${DEBUG} "$INPUT" -o "$GXD/" --extsrc "$EXTSRC"
+fi
 
 num=$(cat $GXD/receipts.tsv | grep -vi CaptureTime | wc -l)
 echo "amount of receipts after run: $num" | tee > $SUMMARYLOG

--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -6,14 +6,12 @@
 #   Appends to receipts.tsv
 #
 
-from collections import namedtuple
-
+import os
 import time
-import zipfile
 
 from xdfile import IncompletePuzzleParse
 
-from xdfile.utils import log, debug, warn, error
+from xdfile.utils import warn, debug, error
 from xdfile.utils import find_files_with_time, parse_pathname, replace_ext, strip_toplevel
 from xdfile.utils import args_parser, get_args, parse_tsv_data, iso8601, open_output, progress
 
@@ -47,9 +45,16 @@ def main():
     p.add_argument('--extsrc', default=None, help='Value for receipts.ExternalSource')
     p.add_argument('--intsrc', default=None, help='Value for receipts.InternalSource')
     p.add_argument('--pubid', default=None, help='PublicationAbbr (pubid) to use')
+    p.add_argument('--skip-unchanged', action='store_true', help='Skip writing .xd and appending receipt if output is byte-identical to existing file')
+    p.add_argument('--reimport', action='store_true', help='Re-parse and rewrite .xd for sources that have already been received (e.g. to pick up parser or decoder fixes).')
+    p.add_argument('--force', action='store_true', help='With --reimport, overwrite even when a different source owns the xdid.')
     args = get_args(parser=p)
 
     outf = open_output()
+
+    # Track shelf paths written during this run, keyed by path -> (ExternalSource, SourceFilename),
+    # to prevent a second source file in the same run from silently overwriting the first.
+    paths_written_this_run = {}
 
     for input_source in args.inputs:
         try:
@@ -69,8 +74,9 @@ def main():
 
             # enumerate all files in this source, reverse-sorted by time
             #  (so most recent edition gets main slot in case of shelving
-            #  conflict)
-            for fn, contents, dt in sorted(find_files_with_time(input_source, strip_toplevel=False), reverse=True, key=lambda x: x[2]):
+            #  conflict); filename is a tiebreaker so the winner is stable
+            #  across runs even when mtimes are equal.
+            for fn, contents, dt in sorted(find_files_with_time(input_source, strip_toplevel=False), reverse=True, key=lambda x: (x[2], x[0])):
                 if fn.endswith(".tsv") or fn.endswith(".log"):
                     continue
 
@@ -99,10 +105,16 @@ def main():
                 existing_xdids = set(r.xdid for r in already_received)
                 if existing_xdids:
                     if len(existing_xdids) > 1:
-                        warn('previously received this same file under multiple xdids:' + ' '.join(existing_xdids))
+                        warn('previously received this same file under multiple xdids: ' + ' '.join(existing_xdids))
                     else:
                         prev_xdid = existing_xdids.pop()
                         debug('already received as %s' % prev_xdid)
+
+                # Default: previously-received sources are skipped entirely (no parse, no write).
+                # --reimport: reprocess and rewrite the .xd.
+                if already_received and not args.reimport:
+                    debug("already received, skipping: %s:%s" % (ExternalSource, SourceFilename))
+                    continue
 
                 # try each parser by extension
                 ext = parse_pathname(fn).ext.lower()
@@ -116,6 +128,8 @@ def main():
                     rejected = "no parser"
                 else:
                     rejected = ""
+                    unchanged = False
+                    owned_by_other = False
                     for parsefunc in possible_parsers:
                         try:
                             try:
@@ -138,7 +152,53 @@ def main():
                             mdtext = "|".join((ExternalSource,InternalSource,SourceFilename))
                             xdid = prev_xdid or catalog.deduce_xdid(xd, mdtext)
                             path = catalog.get_shelf_path(xd, args.pubid, mdtext)
-                            outf.write_file(path + ".xd", xdstr, dt)
+                            if not path:
+                                raise xdfile.NoShelfError("no shelf path for %s" % xd.filename)
+
+                            # --reimport guard: refuse to overwrite if a different source
+                            # owns this xdid (unless --force).
+                            if args.reimport and not args.force and xdid:
+                                latest = metadb.latest_receipt_for_xdid(xdid)
+                                if latest and latest.ExternalSource != ExternalSource:
+                                    warn("xdid %s last imported from '%s', not overwriting from '%s' (use --force to override)" % (
+                                        xdid, latest.ExternalSource, ExternalSource))
+                                    owned_by_other = True
+                                    rejected = ""
+                                    break
+
+                            # Within-run collision guard: if another source in this run already
+                            # wrote this shelf path, skip rather than silently overwrite. Sort
+                            # order makes this deterministic — the earliest-processed file
+                            # (most recent mtime, filename desc on tie) keeps the slot.
+                            own_key = (ExternalSource, SourceFilename)
+                            run_owner = paths_written_this_run.get(path)
+                            if run_owner and run_owner != own_key:
+                                warn("shelf slot %s already written this run by %s; not overwriting with %s" % (
+                                    path + ".xd", run_owner, SourceFilename))
+                                owned_by_other = True
+                                rejected = ""
+                                break
+
+                            unchanged = False
+                            if args.skip_unchanged:
+                                try:
+                                    full = os.path.join(outf.toplevel, path + ".xd")
+                                    if os.path.exists(full):
+                                        new_bytes = xdstr.encode('utf-8')
+                                        if os.path.getsize(full) == len(new_bytes):
+                                            with open(full, 'rb') as f:
+                                                unchanged = f.read() == new_bytes
+                                except AttributeError:
+                                    pass
+
+                            # Claim the slot regardless of whether we actually write, so a later
+                            # source in the same run can't sneak in behind a --skip-unchanged no-op.
+                            paths_written_this_run[path] = own_key
+
+                            if unchanged:
+                                debug("unchanged, skipping: %s" % (path + ".xd"))
+                            else:
+                                outf.write_file(path + ".xd", xdstr, dt)
 
                             rejected = ""
                             break  # stop after first successful parsing
@@ -153,9 +213,16 @@ def main():
                     if rejected:
                         error("could not convert: %s" % rejected)
 
-                    # only add receipt if first time converting this source
+                    # Receipt policy: append only when this is a newly-received source
+                    # that produced a written .xd. Rewrites of already-received sources
+                    # don't add a new receipt (the prior one already binds SourceFilename
+                    # → xdid). Unchanged writes and ownership-blocked writes skip too.
                     if already_received:
                         debug("already received %s:%s" % (ExternalSource, SourceFilename))
+                    elif owned_by_other:
+                        debug("slot owned, receipt skip %s:%s" % (ExternalSource, SourceFilename))
+                    elif unchanged:
+                        debug("unchanged receipt skip %s:%s" % (ExternalSource, SourceFilename))
                     else:
                         receipts.append([
                             CaptureTime,

--- a/scripts/90-split-archive.py
+++ b/scripts/90-split-archive.py
@@ -10,46 +10,112 @@
 import os
 import sys
 import re
-from xdfile.utils import progress, iso8601, get_args, args_parser, open_output, parse_pathname
+import time
+from xdfile.utils import progress, log, iso8601, get_args, args_parser, open_output, parse_pathname
 from xdfile.utils import filetime
 import xdfile.utils
 from xdfile.metadatabase import xd_sources_row, xd_sources_header
 
 
+def status(msg):
+    # end any rolling progress() status cleanly, then log the summary
+    if sys.stdout.isatty():
+        sys.stdout.write("\r\033[K")
+        sys.stdout.flush()
+    log(msg)
+
+
+def load_excludes(paths, files):
+    excludes = set()
+    for p in paths or []:
+        excludes.add(p)
+    for fpath in files or []:
+        with open(fpath) as f:
+            for i, line in enumerate(f):
+                line = line.rstrip('\n')
+                if not line:
+                    continue
+                col0 = line.split('\t', 1)[0]
+                # skip a TSV header row (literal "path" in col 0)
+                if i == 0 and col0 == 'path':
+                    continue
+                excludes.add(col0)
+    return excludes
+
+
 def main():
     p = args_parser('process huge puzzles archive into separate .zip and create sources.tsv')
     p.add_argument('-s', '--source', default=None, help='ExternalSource')
+    p.add_argument('--exclude', action='append',
+                   help='path to exclude from split (may be repeated)')
+    p.add_argument('--excludes-file', action='append',
+                   help='file with one path per line (or TSV; first column); may be repeated')
+    p.add_argument('--min-files', type=int, default=2,
+                   help='minimum number of files for a prefix to get its own zip (default: 2)')
     args = get_args(parser=p)
 
     outf = open_output()
+
+    os.makedirs(args.output, exist_ok=True)
+
+    excludes = load_excludes(args.exclude, args.excludes_file)
+    if excludes:
+        status("loaded %d excluded paths" % len(excludes))
 
     if args.source:
         source = args.source
     else:
         source = parse_pathname(args.inputs[0]).base
 
-    subzips = {}
+    groups = {}
 
+    t_read_start = time.monotonic()
+    n_files = 0
+    n_bytes = 0
+    n_excluded = 0
     for inputfn in args.inputs:
         for fn, contents, dt in xdfile.utils.find_files_with_time(inputfn):
             if not contents:
                 continue
+            if fn in excludes:
+                n_excluded += 1
+                continue
 
-            m = re.match(r'^([a-z]{2,4})[\-0-9]{1}\d.*', parse_pathname(fn).base, flags=re.IGNORECASE)
+            m = re.match(r'^([a-z]{2,})[-_ ]?\d', parse_pathname(fn).base, flags=re.IGNORECASE)
             prefix = m.group(1).lower() if m else 'misc'
-            if prefix not in subzips:
-                zf = xdfile.utils.OutputZipFile(os.path.join(args.output, prefix + ".zip"))
-                sources = []
-                subzips[prefix] = (zf, sources)
-            else:
-                zf, sources = subzips[prefix]
+            groups.setdefault(prefix, []).append((fn, contents, dt))
+            n_files += 1
+            n_bytes += len(contents)
+    t_read = time.monotonic() - t_read_start
+    status("READ phase: %d files, %.1f MB in %.2fs (%.0f files/s, %.1f MB/s); excluded %d" % (
+        n_files, n_bytes / 1e6, t_read,
+        n_files / t_read if t_read else 0,
+        (n_bytes / 1e6) / t_read if t_read else 0,
+        n_excluded))
+
+    for prefix, files in list(groups.items()):
+        if prefix != 'misc' and len(files) < args.min_files:
+            groups.setdefault('misc', []).extend(files)
+            del groups[prefix]
+
+    t_write_start = time.monotonic()
+    for prefix, files in sorted(groups.items()):
+        t_zip_start = time.monotonic()
+        zf = xdfile.utils.OutputZipFile(os.path.join(args.output, prefix + ".zip"))
+        sources = []
+        zip_bytes = 0
+        for fn, contents, dt in files:
             progress("Processing %s -> %s" % (fn, prefix))
             zf.write_file(fn, contents, dt)
-
             sources.append(xd_sources_row(fn, source, iso8601(dt)))
-
-    for zf, sources in subzips.values():
+            zip_bytes += len(contents)
         zf.write_file("sources.tsv", xd_sources_header + "".join(sources))
+        t_zip = time.monotonic() - t_zip_start
+        status("  wrote %s.zip: %d files, %.1f MB in %.2fs" % (
+            prefix, len(files), zip_bytes / 1e6, t_zip))
+    t_write = time.monotonic() - t_write_start
+    status("WRITE phase: %d zips in %.2fs" % (len(groups), t_write))
+    status("TOTAL: read=%.2fs write=%.2fs" % (t_read, t_write))
 
 
 if __name__ == "__main__":

--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -100,9 +100,9 @@ def deduce_xdid(xd, mdtext):
     pubid = find_pubid(mdtext)
     if not pubid:
         publication = get_publication(xd)
-        pubid = publication.PublicationAbbr
-        # Return None if no pub data
-        if not pubid:
+        if publication:
+            pubid = publication.PublicationAbbr
+        else:
             return None
 
     num = xd.get_header('Number')

--- a/xdfile/metadatabase.py
+++ b/xdfile/metadatabase.py
@@ -221,6 +221,22 @@ def check_already_received(ExternalSource, SourceFilename):
     return _receipts_by_source().get((ExternalSource, SourceFilename), [])
 
 
+@utils.memoize
+def _receipts_by_xdid():
+    d = {}
+    for r in read_rows('gxd/receipts'):
+        d.setdefault(r.xdid, []).append(r)
+    return d
+
+
+def latest_receipt_for_xdid(xdid):
+    """Return the most recent receipt for a given xdid, or None."""
+    rows = _receipts_by_xdid().get(xdid, [])
+    if not rows:
+        return None
+    return max(rows, key=lambda r: r.ReceivedTime)
+
+
 def xd_sources_row(SourceFilename, ExternalSource, DownloadTime):
     return COLSEP.join([
         "",  # ReceiptId


### PR DESCRIPTION
Some refactoring in the bulk import script pipeline to help with bwh-2015.tgz work:

18-convert2xd.py:
--skip-unchanged: checks if target file already exists and is the same and skips writing the file + row to receipts.tsv
--reimport: forces a reimport of files that already appear in receipts.tsv with the same source. helpful for rewriting existing files to pick up changes in the conversion. Does not reimport files if the most recent line in receipts.tsv is a different (presumably newer) source.
--force: forces a rewrite of a file even if the most recent import in receipts.tsv was from a different source.

90-split-archive.py:
improved status logging and added timing
--exclude: don't include a certain source file by name
--excludes-file: provide a list of source filenames to exclude
(these are used in conjunction with 91-find-cryptics.py to filter out cryptic puzzles)