### PR TITLE
    Revert "Bump lxml from 6.0.0 to 6.1.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ xword-dl==2025.10.14
 puzpy==0.2.6
 
 # xdfile deps
-lxml==6.1.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
+lxml==6.0.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
 boto3>=1.26.66    # for cloud.py
 botocore>=1.29.66 # for boto3?
 cssselect==1.2.0  # do not see it imported anywhere


### PR DESCRIPTION
    xword-dl is pinned to 6.0.0 so this conflicts.

    This reverts commit 178499e6a3a324f0bf85afc64c0c6e6cdb2ccad7.