### PR TITLE
Small fixes in receipts.tsv (18-convert2xd.py)

### DIFF
--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -66,7 +66,7 @@ def main():
             for fn, contents, dt in find_files_with_time(input_source, ext='.tsv'):
                 progress(fn)
                 for row in parse_tsv_data(contents.decode('utf-8'), "Source"):
-                    innerfn = strip_toplevel(row.SourceFilename)
+                    innerfn = strip_toplevel(row.SourceFilename).replace('\\', '/')
                     if innerfn in source_files:
                         warn("%s: already in source_files!" % innerfn)
                         continue
@@ -83,7 +83,7 @@ def main():
                 if not contents:  # 0-length files
                     continue
 
-                innerfn = strip_toplevel(fn)
+                innerfn = strip_toplevel(fn).replace('\\', '/')
                 if innerfn in source_files:
                     srcrow = source_files[innerfn]
                     CaptureTime = srcrow.DownloadTime

--- a/xdfile/metadatabase.py
+++ b/xdfile/metadatabase.py
@@ -177,7 +177,7 @@ def append_row(tablename, row):
     if addhdr:
         fp.write(COLSEP.join(xddb_headers[tablename].split()) + EOL)
 
-    fp.write(COLSEP.join([str(x) for x in row]) + EOL)
+    fp.write(COLSEP.join(["" if x is None else str(x) for x in row]) + EOL)
     fp.close()
 
 


### PR DESCRIPTION
Two minor bug fixes to receipts.tsv
- convert windows paths to unix in receipts.tsv source file column.
- don't write None in xdid column. funny side-effect of a previous bug fix (49f1664b0)

