### PR TITLE
install latest xword-dl to pick up important bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 crossword==0.1.2
-xword-dl==2025.10.14
-puzpy==0.2.6
+xword-dl @ git+https://github.com/thisisparker/xword-dl.git@main
+puzpy>=0.2.6
 
 # xdfile deps
-lxml==6.0.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
+lxml==6.1.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
 boto3>=1.26.66    # for cloud.py
 botocore>=1.29.66 # for boto3?
 cssselect==1.2.0  # do not see it imported anywhere


### PR DESCRIPTION
xword-dl has some critical updates:
- latest libxml (security issue)
- fix for latimes and other amuselabs-based publications
- latest puz.py

Since we're not sure when Parker plans to release, let's install main from github for now. we can pin the version again when he releases.