### PR TITLE
remove legacycgi in favor of using html.escape

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ lxml==6.0.0       # for ccxml2xd, uxml2xd, xwordinfo2xd
 boto3>=1.26.66    # for cloud.py
 botocore>=1.29.66 # for boto3?
 cssselect==1.2.0  # do not see it imported anywhere
-legacy-cgi; python_version >= '3.13'

--- a/scripts/36-mkwww-deepclues.py
+++ b/scripts/36-mkwww-deepclues.py
@@ -8,7 +8,7 @@
 from queries.similarity import find_clue_variants, load_answers, load_clues, boil
 from xdfile import utils
 from xdfile.html import mktag, html_select_options, html_select_options_freq, grid_to_html
-import cgi
+import html
 
 from xdfile.utils import find_files, progress, info
 from xdfile import ClueAnswer
@@ -17,7 +17,7 @@ import xdfile
 
 
 def esc(s):
-    return cgi.escape(s)
+    return html.escape(s)
 
 
 def prev_uses(pub_uses, mainxd, mainclue):

--- a/scripts/39-mkwww-logs.py
+++ b/scripts/39-mkwww-logs.py
@@ -5,7 +5,7 @@
 #
 #  takes all .log files and generates wwwroot/<YYYYMMDD>/index.html
 
-import cgi
+import html
 
 from xdfile.utils import find_files_with_time, open_output, get_args, iso8601
 
@@ -14,7 +14,7 @@ def main():
     outwww = open_output()
     log_html = ''
     for fn, contents, dt in sorted(find_files_with_time(*args.inputs, ext=".log"), key=lambda x: x[2]):  # earliest first
-        log_html += '\n\n<h2>%s</h2><pre>%s</pre>' % (fn, cgi.escape(contents.decode("utf-8")))
+        log_html += '\n\n<h2>%s</h2><pre>%s</pre>' % (fn, html.escape(contents.decode("utf-8")))
 
     datestr = iso8601()
     outwww.write_html("logs.html", log_html, title="logs for " + datestr)


### PR DESCRIPTION
we were importing legacy-cgi because cgi.escape was removed in python 3.8. recommended migration path is to replace cgi.escape with html.escape.  We can then drop the legacy-cgi dep.