### PR TITLE
pipeline logging, perf, and bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WWWZIP=/tmp/${NOW}-www.zip
 S3_REGION=us-west-2
 S3_WWW=s3://xd.saul.pw
 
-.PHONY: gxd.sqlite
+.PHONY: gxd.sqlite clean clean-cache
 
 all: analyze gridmatches website
 
@@ -39,12 +39,12 @@ import:
 	cp ${WWWZIP} ${SRC_DIR}/${YEAR}/
 
 checkdups:
-	scripts/25-analyze-puzzle.py -o ${WWW_DIR}/ -c ${GXD_DIR} ${GXD_DIR}
+	scripts/25-analyze-puzzle.py -o ${WWW_DIR}/ -c ${GXD_DIR}
 
 analyze:
 	mkdir -p ${WWW_DIR}
 	mkdir -p ${PUB_DIR}
-	scripts/21-clean-metadata.py ${GXD_DIR}
+	scripts/21-clean-metadata.py -c ${GXD_DIR}
 	scripts/27-pubyear-stats.py -c ${GXD_DIR}
 	scripts/26-mkzip-clues.py -c ${GXD_DIR} -o ${WWW_DIR}/xd-clues.zip
 	scripts/29-mkzip-metadata.py -c ${GXD_DIR} -o ${WWW_DIR}/xd-metadata.zip
@@ -52,8 +52,9 @@ analyze:
 website: RECENT_XDS_FILE=/tmp/${NOW}-recent-xds.txt
 website: website-static
 	mkdir -p ${WWW_DIR}/pub/gxd
-	zip -q -r ${WWW_DIR}/xd-puzzles.zip `cat ${GXD_DIR}/pubs.txt`
-	git -C ${GXD_DIR} log --pretty="format:" --since="30 days ago" --name-only | sort -u > ${RECENT_XDS_FILE}
+	#zip -q -r ${WWW_DIR}/xd-puzzles.zip `cat ${GXD_DIR}/pubs.txt`
+	git -C ${GXD_DIR} log --diff-filter=d --pretty="format:" --since="1 day ago" --name-only | grep '\.xd$$' | sort -u | sed 's,^,${GXD_DIR}/,' > ${RECENT_XDS_FILE}
+	@echo "INFO: found $$(wc -l < ${RECENT_XDS_FILE}) new or modified .xd files in the last day"
 	scripts/37-pubyear-svg.py -o ${WWW_DIR}/ # /pub/ index
 	scripts/33-mkwww-words.py -c ${GXD_DIR} -o ${WWW_DIR}/ # /pub/word/<ANSWER>
 	scripts/34-mkwww-clues.py -c ${GXD_DIR} -o ${WWW_DIR}/ --inputs-from ${RECENT_XDS_FILE} # /pub/clue/<boiledclue>
@@ -81,7 +82,7 @@ gridmatches: gxd.sqlite src/gridcmp.so
 	sqlite3 -header -separator '	' gxd.sqlite "select * from gridmatches;" > ${GXD_DIR}/similar.tsv
 
 gxd.sqlite: ${GXD_DIR}
-	time ./scripts/26-mkdb-sqlite.py $@ ${GXD_DIR}
+	time ./scripts/26-mkdb-sqlite.py -o $@ -c ${GXD_DIR}
 	cat src/inputgridmatches.sql | sqlite3 $@
 
 gxd.zip:
@@ -89,3 +90,13 @@ gxd.zip:
 
 src/gridcmp.so: src/sqlite_gridcmp.c
 	gcc -g -fPIC -shared $< -o $@
+
+# Remove generated artifacts (pub/, wwwroot/, gxd.sqlite). Preserves the
+# corpus cache, which is expensive to rebuild — use clean-cache for that.
+clean:
+	rm -rf ${PUB_DIR} ${WWW_DIR}
+	rm -f gxd.sqlite
+
+# Remove the corpus cache file(s) so the next run rebuilds from gxd/.
+clean-cache:
+	rm -f .corpus.*.jsonl .corpus.*.jsonl.tmp

--- a/queries/remix.py
+++ b/queries/remix.py
@@ -4,7 +4,7 @@ import string
 import random
 
 from xdfile.utils import get_args, open_output, find_files, debug, info, error, get_log, COLUMN_SEPARATOR, EOL
-from xdfile.utils import parse_tsv, progress, parse_pathname, iso8601
+from xdfile.utils import parse_tsv, parse_pathname, iso8601
 from xdfile import xdfile, BLOCK_CHAR
 
 
@@ -69,7 +69,6 @@ def mutate(xd, words, chance=1):
     for hwd, vwd, i, j, r, c in each_word_cross(xd):
         hwd_a, pivot_char, hwd_b = hwd[:i], hwd[i], hwd[i:][1:]
         vwd_a, pivot_char, vwd_b = vwd[:j], vwd[j], vwd[j:][1:]
-        progress("%s[%s]%s/%s[%s]%s" % (hwd_a, pivot_char, hwd_b, vwd_a, pivot_char, vwd_b))
 
         mutations_this_square = []
 
@@ -95,6 +94,8 @@ def mutate(xd, words, chance=1):
 
 def load_clues():
     ret = {} # ["pubid"] = { ["ANSWER"] = { ["simplified clue text"] = set(fullclues) } }
+    info("loading clues from clues.tsv...")
+    nrows = 0
     for r in parse_tsv("clues.tsv", "AnswerClue"):
         try:
             pubid, dt, answer, clue = r
@@ -102,7 +103,7 @@ def load_clues():
             print(str(e), r)
             continue
 
-        progress(dt, every=100000)
+        nrows += 1
 
         if not clue:
             continue
@@ -129,7 +130,7 @@ def load_clues():
             clues[boiled_clue] = set()
         clues[boiled_clue].add(clue)
 
-    progress()
+    info("loaded %d clue rows, done" % nrows)
     return ret
 
 

--- a/queries/similarity.py
+++ b/queries/similarity.py
@@ -102,7 +102,11 @@ def unboil(bc):
 
 def load_clues():
     if not g_boiled_clues:
+        # skip clues from redacted contest puzzles (whole puzzle is all X's)
+        redacted = {xd.xdid() for xd in corpus() if xd.is_redacted()}
         for ca in clues():
+            if ca.xdid() in redacted:
+                continue
             boiled_clue = boil(ca.clue)
             if not boiled_clue:
                 continue
@@ -121,7 +125,11 @@ def load_clues():
 # bclues is all boiled clues for this particular answer: { [bc] -> #uses }
 def load_answers():
     if not g_answers:
+        # skip clues from redacted contest puzzles (whole puzzle is all X's)
+        redacted = {xd.xdid() for xd in corpus() if xd.is_redacted()}
         for ca in clues():
+            if ca.xdid() in redacted:
+                continue
             if ca.answer not in g_answers:
                 ans = dict()
                 g_answers[ca.answer] = ans

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ boto3>=1.26.66    # for cloud.py
 botocore>=1.29.66 # for boto3?
 cssselect==1.2.0  # do not see it imported anywhere
 legacy-cgi; python_version >= '3.13'
+orjson==3.11.8    # for fast loading of corpus cache

--- a/scripts/21-clean-metadata.py
+++ b/scripts/21-clean-metadata.py
@@ -145,13 +145,11 @@ def clean_headers(xd):
 
 
 def main():
-    args = utils.get_args(desc='outputs cleaned puzzle metadata rows')
+    utils.get_args(desc='outputs cleaned puzzle metadata rows')
 
-    for input_source in args.inputs:
-        for fn, contents in utils.find_files(input_source, ext='.xd'):
-            xd = xdfile.xdfile(contents.decode('utf-8'), fn)
-            clean_headers(xd)
-            metadb.update_puzzles_row(xd)
+    for xd in xdfile.iter_corpus():
+        clean_headers(xd)
+        metadb.update_puzzles_row(xd)
 
 
 if __name__ == "__main__":

--- a/scripts/25-analyze-puzzle.py
+++ b/scripts/25-analyze-puzzle.py
@@ -7,8 +7,8 @@
 #
 
 from queries.similarity import find_similar_to, find_clue_variants, load_clues, load_answers
-from xdfile.utils import get_args, open_output, find_files, info
-from xdfile import xdfile, corpus, ClueAnswer
+from xdfile.utils import get_args, open_output, info
+from xdfile import corpus, iter_corpus, ClueAnswer
 from xdfile import utils, metadatabase as metadb
 
 
@@ -21,9 +21,7 @@ def main():
 
     num_processed = 0
     prev_similar = metadb.read_rows('gxd/similar')
-    for fn, contents in find_files(*args.inputs, ext=".xd"):
-        mainxd = xdfile(contents.decode('utf-8'), fn)
-
+    for mainxd in iter_corpus():
         if mainxd.is_redacted():
             continue  # answers are all 'X' — skip grid comparison
 

--- a/scripts/25-analyze-puzzle.py
+++ b/scripts/25-analyze-puzzle.py
@@ -7,7 +7,7 @@
 #
 
 from queries.similarity import find_similar_to, find_clue_variants, load_clues, load_answers
-from xdfile.utils import get_args, open_output, find_files, info, progress
+from xdfile.utils import get_args, open_output, find_files, info
 from xdfile import xdfile, corpus, ClueAnswer
 from xdfile import utils, metadatabase as metadb
 
@@ -22,8 +22,10 @@ def main():
     num_processed = 0
     prev_similar = metadb.read_rows('gxd/similar')
     for fn, contents in find_files(*args.inputs, ext=".xd"):
-        progress(fn)
         mainxd = xdfile(contents.decode('utf-8'), fn)
+
+        if mainxd.is_redacted():
+            continue  # answers are all 'X' — skip grid comparison
 
         if mainxd.xdid() in prev_similar:
             continue  # skip reprocessing .xd that are already in similar.tsv
@@ -51,8 +53,6 @@ def main():
         nstaleanswers = 0
         ntotalclues = 0
         for pos, mainclue, mainanswer in mainxd.iterclues():
-            progress(mainanswer)
-
             poss_answers = []
             pub_uses = { }  # [pubid] -> set(ClueAnswer)
 

--- a/scripts/26-mkdb-sqlite.py
+++ b/scripts/26-mkdb-sqlite.py
@@ -1,31 +1,29 @@
 #!/usr/bin/env python3
 
 '''
-Usage: $0 <gxd.sqlite> <input_dir>
+Usage: $0 -o <gxd.sqlite> -c <corpus>
 
 Create and populate <gxd.sqlite> database with metadata, grid, and clues.
 '''
 
-import os
+import sqlite3
 import sys
 
-import xdfile
-
-def find_files(path, ext=''):
-    for root, directories, files in os.walk(path):
-        for fn in files:
-            if fn.endswith(ext):
-                yield os.path.join(root, fn)
+from xdfile import iter_corpus
+from xdfile.utils import get_args, info
 
 
-def main(outdb, inputdir):
-    import sqlite3
-    con = sqlite3.connect(outdb)
+def main():
+    args = get_args(desc='create sqlite db with metadata, grid, and clues')
+    if not args.output:
+        sys.exit("usage: %s -o <gxd.sqlite> -c <corpus>" % sys.argv[0])
+
+    # Incremental: previously-imported puzzles are skipped. To force a full
+    # rebuild (e.g. after a parser change), delete the sqlite file first.
+    con = sqlite3.connect(args.output)
     cur = con.cursor()
 
-    # puzzle metadata
-    cur.execute('DROP TABLE IF EXISTS puzzles')
-    cur.execute('''CREATE TABLE puzzles (
+    cur.execute('''CREATE TABLE IF NOT EXISTS puzzles (
         xdfn TEXT PRIMARY KEY,
         xdid TEXT,
         date TEXT,
@@ -38,7 +36,6 @@ def main(outdb, inputdir):
         grid TEXT)
     ''')
 
-    cur.execute('DROP TABLE IF EXISTS clues')
     cur.execute('''CREATE TABLE IF NOT EXISTS clues (
         xdid TEXT,
         position TEXT,
@@ -46,8 +43,11 @@ def main(outdb, inputdir):
         clue TEXT)
     ''')
 
-    for xdfn in find_files(inputdir, ext='.xd'):
-        xd = xdfile.parse(xdfn)
+    existing = set(row[0] for row in cur.execute('SELECT xdfn FROM puzzles'))
+
+    for xd in iter_corpus():
+        if xd.filename in existing:
+            continue
 
         w = xd.width()
         h = xd.height()
@@ -56,7 +56,7 @@ def main(outdb, inputdir):
         size = f'{w}x{h}{rebus}{special}'
 
         cur.execute('INSERT INTO puzzles VALUES (?,?,?,?,?,?,?,?,?,?)', (
-            xdfn,
+            xd.filename,
             xd.xdid(),
             xd.get_header("Date"),
             size,
@@ -72,8 +72,12 @@ def main(outdb, inputdir):
             if pos:
                 cur.execute('INSERT INTO clues VALUES (?, ?, ?, ?)', (xd.xdid(), pos, answer, clue))
 
+    info("creating index...")
+    cur.execute('CREATE INDEX IF NOT EXISTS puzzles_size_date ON puzzles(size, date)')
+
+    info("committing...")
     con.commit()
 
 
 if __name__ == "__main__":
-    main(*sys.argv[1:])
+    main()

--- a/scripts/26-mkzip-clues.py
+++ b/scripts/26-mkzip-clues.py
@@ -16,13 +16,21 @@ def main():
     outf.toplevel = 'xd'
     outf.write_file('README', open('doc/zip-README').read())
 
-    all_clues = [(ca.pubid, str(xdfile.year_from_date(ca.date)), ca.answer, ca.clue) for ca in xdfile.clues()]
+    # skip clues from redacted contest puzzles (whole puzzle is all X's)
+    redacted = {xd.xdid() for xd in xdfile.corpus() if xd.is_redacted()}
+    all_clues = [(ca.pubid, str(xdfile.year_from_date(ca.date)), ca.answer, ca.clue)
+                 for ca in xdfile.clues()
+                 if ca.xdid() not in redacted]
 
+    utils.info("sorting and formatting %d clues..." % len(all_clues))
     clues_tsv = ''
-
     clues_tsv += '\t'.join("pubid year answer clue".split()) + '\n'
     clues_tsv += '\n'.join('\t'.join(cluerow) for cluerow in sorted(all_clues))
+    utils.info("sorting and formatting clues, done")
+
+    utils.info("writing clues.tsv to %s..." % outf.filename)
     outf.write_file('clues.tsv', clues_tsv)
+    utils.info("writing clues.tsv, done")
 
 if __name__ == "__main__":
     main()

--- a/scripts/27-pubyear-stats.py
+++ b/scripts/27-pubyear-stats.py
@@ -3,7 +3,7 @@
 import string
 from collections import Counter
 
-from xdfile.utils import debug, info
+from xdfile.utils import debug
 from xdfile import utils, metadatabase as metadb
 from xdfile import dow_from_date
 import xdfile
@@ -124,11 +124,11 @@ def main():
                 xd1 = xdfile.get_xd(r.xdid)
                 xd2 = xdfile.get_xd(r.match_xdid)
                 if xd1 is None:
-                    info("%s: similar puzzle %s not in corpus" % (r.match_xdid, r.xdid))
+                    debug("%s: similar puzzle %s not in corpus" % (r.match_xdid, r.xdid))
                     continue
 
                 if xd2 is None:
-                    info("%s: similar puzzle %s not in corpus" % (r.xdid, r.match_xdid))
+                    debug("%s: similar puzzle %s not in corpus" % (r.xdid, r.match_xdid))
                     continue
 
                 dt1 = xd1.get_header('Date')

--- a/scripts/29-mkzip-metadata.py
+++ b/scripts/29-mkzip-metadata.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Usage: $0 -o xd-metadata.zip
 

--- a/scripts/33-mkwww-words.py
+++ b/scripts/33-mkwww-words.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-from xdfile.utils import get_args, open_output
+from xdfile.utils import args_parser, get_args, open_output
 from xdfile.html import th, td, mkhref, html_select_options
 from xdfile import clues, metadatabase as metadb, utils
+import xdfile
 
 
 
@@ -34,12 +35,19 @@ def mkwww_wordpage(answer):
 
 def main():
     global all_uses
-    args = get_args('create word pages and index')
+    p = args_parser(desc='create word pages and index')
+    p.add_argument('-N', '--top-n', type=int, default=100,
+                   help='generate per-word pages for the top N most-used answers (default: 100)')
+    args = get_args(parser=p)
     outf = open_output()
 
     all_uses = {}
 
+    # skip clues from redacted contest puzzles (whole puzzle is all X's)
+    redacted = {xd.xdid() for xd in xdfile.corpus() if xd.is_redacted()}
     for ca in clues():
+        if ca.xdid() in redacted:
+            continue
         if ca.answer not in all_uses:
             all_uses[ca.answer] = []
         all_uses[ca.answer].append(ca)
@@ -52,7 +60,7 @@ def main():
 
     wordpages_to_make = set(args.inputs)
 
-    for answer, uses in sorted(all_uses.items(), reverse=True, key=lambda x: len(x[1]))[:100]:
+    for answer, uses in sorted(all_uses.items(), reverse=True, key=lambda x: len(x[1]))[:args.top_n]:
         wordpages_to_make.add(answer)
         h += td(mkhref(answer.upper(), answer.upper()),
                 len(uses),

--- a/scripts/34-mkwww-clues.py
+++ b/scripts/34-mkwww-clues.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from queries.similarity import load_clues, unboil, boil
-from xdfile.utils import args_parser, get_args, open_output, find_files
+from xdfile.utils import args_parser, get_args, open_output, find_files, info, progress, warn
 from xdfile.html import th, td, mkhref, html_select_options
 from xdfile import clues
 import xdfile
@@ -55,7 +55,9 @@ def main():
         if xd.is_redacted():
             continue
         for pos, mainclue, mainanswer in xd.iterclues():
-            cluepages_to_make.add(boil(mainclue))
+            bc = boil(mainclue)
+            if bc:  # boil() returns None for clues with cross-references like "5 across"
+                cluepages_to_make.add(bc)
 
 
     # add top 100 most used boiled clues from corpus
@@ -84,12 +86,26 @@ def main():
 
     most_ambig += '</table>'
 
+    info("writing %d per-clue HTML pages..." % len(cluepages_to_make))
+    nwritten = 0
     for bc in cluepages_to_make:
+        # boiled clue is used as a directory name; skip ones that would blow past
+        # Windows MAX_PATH (260 chars) when combined with the wwwroot/pub/clue/.../index.html prefix
+        if len(bc) > 200:
+            warn("skipping clue page (boiled clue too long, %d chars): %s..." % (len(bc), bc[:60]))
+            continue
         contents = mkwww_cluepage(bc)
         if contents:
-            outf.write_html('pub/clue/%s/index.html' % bc, contents, title=bc)
+            outpath = 'pub/clue/%s/index.html' % bc
+            progress(outpath, every=10)
+            outf.write_html(outpath, contents, title=bc)
+            nwritten += 1
+    progress()
+    info("wrote %d per-clue pages, done" % nwritten)
 
+    info("writing clue index page...")
     outf.write_html('pub/clue/index.html', biggest_clues + most_ambig, title="Clues")
+    info("clue index page, done")
 
 
 main()

--- a/scripts/34-mkwww-clues.py
+++ b/scripts/34-mkwww-clues.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from queries.similarity import load_clues, unboil, boil
-from xdfile.utils import args_parser, get_args, open_output, find_files, progress
+from xdfile.utils import args_parser, get_args, open_output, find_files
 from xdfile.html import th, td, mkhref, html_select_options
 from xdfile import clues
 import xdfile

--- a/scripts/34-mkwww-clues.py
+++ b/scripts/34-mkwww-clues.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from queries.similarity import load_clues, unboil, boil
-from xdfile.utils import get_args, open_output, find_files, progress
+from xdfile.utils import args_parser, get_args, open_output, find_files, progress
 from xdfile.html import th, td, mkhref, html_select_options
 from xdfile import clues
 import xdfile
@@ -32,7 +32,10 @@ def mkwww_cluepage(bc):
 
 def main():
     global boiled_clues
-    args = get_args('create clue index')
+    p = args_parser(desc='create clue index')
+    p.add_argument('-N', '--top-n', type=int, default=100,
+                   help='generate per-clue pages for top N most-used and top N most-ambiguous clues (default: 100)')
+    args = get_args(parser=p)
     outf = open_output()
 
     boiled_clues = load_clues()
@@ -48,8 +51,9 @@ def main():
 
     # add all boiled clues from all input .xd files
     for fn, contents in find_files(*args.inputs, ext='.xd'):
-        progress(fn)
         xd = xdfile.xdfile(contents.decode('utf-8'), fn)
+        if xd.is_redacted():
+            continue
         for pos, mainclue, mainanswer in xd.iterclues():
             cluepages_to_make.add(boil(mainclue))
 
@@ -59,7 +63,7 @@ def main():
 
     biggest_clues += '<table class="clues most-used-clues">'
     biggest_clues += th("clue", "# uses", "answers used with this clue")
-    for n, bc, ans in sorted(bcs, reverse=True)[:100]:
+    for n, bc, ans in sorted(bcs, reverse=True)[:args.top_n]:
         cluepages_to_make.add(bc)
         biggest_clues += td(mkhref(unboil(bc), bc), n, html_select_options(ans))
 
@@ -70,7 +74,7 @@ def main():
     most_ambig += '<table class="clues most-different-answers">'
     most_ambig += th("Clue", "answers")
 
-    for n, bc, ans in sorted(bcs, reverse=True, key=lambda x: len(set(x[2])))[:100]:
+    for n, bc, ans in sorted(bcs, reverse=True, key=lambda x: len(set(x[2])))[:args.top_n]:
         cluepages_to_make.add(bc)
         clue = mkhref(unboil(bc), bc)
         if 'quip' in bc or 'quote' in bc or 'theme' in bc or 'riddle' in bc:

--- a/scripts/35-mkwww-diffs.py
+++ b/scripts/35-mkwww-diffs.py
@@ -7,7 +7,7 @@ from xdfile import utils
 from xdfile.html import mktag, grid_diff_html
 from xdfile.utils import warn
 
-from xdfile.utils import debug, progress
+from xdfile.utils import debug, progress, info
 #from xdfile import xdfile, corpus, ClueAnswer, BLOCK_CHAR
 from xdfile import metadatabase as metadb
 import xdfile
@@ -27,8 +27,14 @@ def main():
         xdids_todo[row.xdid].append(row)
 
 
-    for mainxdid in xdids_todo:
+    xds_todo = list(xdids_todo)
+    info("generating diffs for %d puzzles..." % len(xds_todo))
+    # ~20 info() lines spread evenly so CI logs stay readable for any list size
+    info_every = max(1, len(xds_todo) // 20)
+    for npuzzle, mainxdid in enumerate(xds_todo):
         progress(mainxdid)
+        if npuzzle and npuzzle % info_every == 0:
+            info("  ... %d/%d (%.0f%%) diffs generated" % (npuzzle, len(xds_todo), 100 * npuzzle / len(xds_todo)))
 
         mainxd = xdfile.get_xd(mainxdid)
         if not mainxd:
@@ -115,6 +121,8 @@ def main():
         diff_h += mktag('/table')
 
         outf.write_html('pub/%s/index.html' % mainxdid, diff_h, title='Comparison for ' + mainxdid)
+    progress()
+    info("generated %d diffs, done" % len(xds_todo))
 
 
 

--- a/scripts/35-mkwww-diffs.py
+++ b/scripts/35-mkwww-diffs.py
@@ -5,7 +5,7 @@
 import difflib
 from xdfile import utils
 from xdfile.html import mktag, grid_diff_html
-from xdfile.utils import info, warn
+from xdfile.utils import warn
 
 from xdfile.utils import debug, progress
 #from xdfile import xdfile, corpus, ClueAnswer, BLOCK_CHAR
@@ -18,7 +18,6 @@ def main():
     utils.get_args('generates .html diffs for all puzzles in similar.tsv')
     outf = utils.open_output()
 
-    utils.parse_tsv('gxd/similar.tsv', 'Similar')
     xdids_todo = {}
 
     for row in metadb.xd_similar_all():
@@ -36,8 +35,11 @@ def main():
             warn('%s not in corpus' % mainxdid)
             continue
 
+        if mainxd.is_redacted():
+            continue  # answers are all 'X' — skip diff rendering
+
         matches = xdids_todo[mainxdid]
-        info('generating diffs for %s (%d matches)' % (mainxdid, len(matches)))
+        debug('generating diffs for %s (%d matches)' % (mainxdid, len(matches)))
 
         xddates = {}
         xddates[mainxdid] = mainxd.date() # Dict to store XD dates for further sort
@@ -64,6 +66,8 @@ def main():
             # Continue if can't load xdid
             if not xd:
                 continue
+            if xd.is_redacted():
+                continue  # answers are all 'X' — skip from diff comparison
             xddates[xdid] = xd.date()
             # output each grid
             html_grids[xdid] = grid_diff_html(xd, compare_with=mainxd)

--- a/scripts/36-mkwww-deepclues.py
+++ b/scripts/36-mkwww-deepclues.py
@@ -10,7 +10,7 @@ from xdfile import utils
 from xdfile.html import mktag, html_select_options, html_select_options_freq, grid_to_html
 import cgi
 
-from xdfile.utils import find_files, progress, debug
+from xdfile.utils import find_files, progress, debug, info
 from xdfile import ClueAnswer
 from xdfile import metadatabase as metadb
 import xdfile
@@ -79,9 +79,14 @@ def main():
 
     xds_todo = [xd for xd in xds if not xd.is_redacted()]
 
-    for mainxd in xds_todo:
+    info("generating deepclues for %d puzzles..." % len(xds_todo))
+    # ~20 info() lines spread evenly so CI logs stay readable for any list size
+    info_every = max(1, len(xds_todo) // 20)
+    for npuzzle, mainxd in enumerate(xds_todo):
         mainxdid = mainxd.xdid()
         progress(mainxdid)
+        if npuzzle and npuzzle % info_every == 0:
+            info("  ... %d/%d (%.0f%%) deepclues generated" % (npuzzle, len(xds_todo), 100 * npuzzle / len(xds_todo)))
 
         metadb.xd_similar(mainxdid)
 
@@ -167,6 +172,8 @@ def main():
         debug('writing deepclues for %s' % mainxdid)
         outf.write_html('pub/deep/%s/index.html' % mainxdid, diff_h,
                     title='Deep clue analysis for ' + mainxdid)
+    progress()
+    info("generated %d deepclues, done" % len(xds_todo))
 
 
 if __name__ == '__main__':

--- a/scripts/36-mkwww-deepclues.py
+++ b/scripts/36-mkwww-deepclues.py
@@ -10,7 +10,7 @@ from xdfile import utils
 from xdfile.html import mktag, html_select_options, html_select_options_freq, grid_to_html
 import cgi
 
-from xdfile.utils import find_files, progress, info
+from xdfile.utils import find_files, progress, debug
 from xdfile import ClueAnswer
 from xdfile import metadatabase as metadb
 import xdfile
@@ -69,12 +69,15 @@ def main():
     args = utils.get_args('generates .html diffs with deep clues for all puzzles in similar.tsv')
     outf = utils.open_output()
 
-    utils.parse_tsv('gxd/similar.tsv', 'Similar')
+    if args.inputs:
+        xds = [xdfile.xdfile(contents.decode('utf-8'), fn)
+               for fn, contents in find_files(*args.inputs, ext='.xd')]
+    else:
+        # default: puzzles in similar.tsv with match_pct > 25 (per docstring)
+        xdids = {row.xdid for row in metadb.xd_similar_all() if row.match_pct > 25}
+        xds = [xd for xd in (xdfile.get_xd(x) for x in xdids) if xd is not None]
 
-    xds_todo = []
-    for fn, contents in find_files(*args.inputs, ext='.xd'):
-        xd = xdfile.xdfile(contents.decode('utf-8'), fn)
-        xds_todo.append(xd)
+    xds_todo = [xd for xd in xds if not xd.is_redacted()]
 
     for mainxd in xds_todo:
         mainxdid = mainxd.xdid()
@@ -161,7 +164,7 @@ def main():
         diff_h += mktag('table', 'deepclues') + dcl_html + mktag('/table')
         diff_h += '</div>'
 
-        info('writing deepclues for %s' % mainxdid)
+        debug('writing deepclues for %s' % mainxdid)
         outf.write_html('pub/deep/%s/index.html' % mainxdid, diff_h,
                     title='Deep clue analysis for ' + mainxdid)
 

--- a/scripts/37-pubyear-svg.py
+++ b/scripts/37-pubyear-svg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 import string

--- a/scripts/37-pubyear-svg.py
+++ b/scripts/37-pubyear-svg.py
@@ -402,9 +402,11 @@ def main():
     year_header = gen_year_header(allyears)
     html_out.extend(year_header)
 
+    utils.info("computing puzzle counts for %d publications..." % len(pubyears_idx))
     pubs_total = {}
     for pubid in pubyears_idx:
         pubs_total[pubid] = len(metadb.xd_puzzles(pubid))
+    utils.info("puzzle counts done")
 
     # sort rows by number of puzzles
     sorted_pubs = sorted(pubs_total.keys(), key=lambda pubid: pubs_total[pubid], reverse=True)
@@ -418,6 +420,7 @@ def main():
             pubname = pubobj.PublicationName or pubobj.PublisherName
         else:
             pubname = pub
+        utils.info("rendering %s (%d puzzles)..." % (pub, pubs_total[pub]))
         html_out.append('<tr><td class="header">{}</td>'.format(html.mkhref(pubname, 'pub/' + pub)))
 
         for year in sorted(allyears):
@@ -426,7 +429,9 @@ def main():
             if py_td:
                 html_out.append(py_td)
                 if not args.pubonly:
-                    outf.write_html('pub/{pub}{year}/index.html'.format(**locals()), pubyear_html(pub, year),
+                    outpath = 'pub/{pub}{year}/index.html'.format(**locals())
+                    utils.progress(outpath)
+                    outf.write_html(outpath, pubyear_html(pub, year),
                                     "{pubname}, {year}".format(**locals()))
             else:
                 # otherwise

--- a/scripts/44-mkwww-pages.py
+++ b/scripts/44-mkwww-pages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Usage:
 #   $0 -o wwwroot/ pagebody.html [...]

--- a/xdfile/metadatabase.py
+++ b/xdfile/metadatabase.py
@@ -1,4 +1,5 @@
 
+import atexit
 import os.path
 import codecs
 from collections import namedtuple
@@ -133,8 +134,8 @@ def xd_puzzles(xdid=''):
 
 
 def get_author(xdid=''):
-    r = xd_puzzles(xdid)
-    return str(r[0].Author) if r else "???"
+    p = xd_puzzle(xdid)
+    return str(p.Author) if p else "???"
 
 
 @utils.memoize
@@ -169,16 +170,21 @@ def read_rows(tablename):
     return utils.parse_tsv_rows(tsvpath, basename)
 
 
+_open_tables = {}
+
+atexit.register(lambda: [fp.close() for fp in _open_tables.values()])
+
+
 def append_row(tablename, row):
-    tsvpath = tablename + ".tsv"
-    addhdr = not os.path.exists(tsvpath)
+    if tablename not in _open_tables:
+        tsvpath = tablename + ".tsv"
+        addhdr = not os.path.exists(tsvpath)
+        fp = open(tsvpath, 'a', encoding='utf-8')
+        if addhdr:
+            fp.write(COLSEP.join(xddb_headers[tablename].split()) + EOL)
+        _open_tables[tablename] = fp
 
-    fp = codecs.open(tsvpath, 'a', encoding='utf-8')
-    if addhdr:
-        fp.write(COLSEP.join(xddb_headers[tablename].split()) + EOL)
-
-    fp.write(COLSEP.join([str(x) for x in row]) + EOL)
-    fp.close()
+    _open_tables[tablename].write(COLSEP.join([str(x) for x in row]) + EOL)
 
 
 def get_last_receipt_id():
@@ -249,7 +255,7 @@ def xd_recent_download(pubid, dt):
 
 def update_puzzles_row(xd):
     # INSERT only for now
-    if xd.xdid() in xd_puzzles():
+    if xd.xdid() in xd_puzzles_dict():
         raise Error('record already exists; UPDATE not implemented')
 
     fields = [

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -135,6 +135,10 @@ def get_args(desc="", parser=None):
     parser.add_argument('-v', '--verbose', dest='verbose', action='count', default=0)
     parser.add_argument('-d', '--debug', dest='debug', action='store_true', default=False, help='abort on exception')
     parser.add_argument('-c', '--corpus', dest='corpusdir', default='crosswords', help='corpus source')
+    parser.add_argument('--corpus-cache', dest='corpus_cache', default=None,
+                        help='cache file path (default: .corpus.<corpus>.jsonl)')
+    parser.add_argument('--no-corpus-cache', dest='corpus_cache_disabled', action='store_true', default=False,
+                        help='disable corpus caching for this run')
     g_args = parser.parse_args()
 
     if g_args.inputs_from:
@@ -214,7 +218,7 @@ def find_files_with_time(*paths, **kwargs):
             yield fullfn, open(fullfn, 'rb').read(), filetime(fullfn)
 
       except FileNotFoundError as e:
-          error("find_files_with_time(): %s" % str(e))
+          warn("find_files_with_time(): %s" % str(e))
 
     # reset progress indicator after processing all files
     progress()

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -66,6 +66,10 @@ def log(s, minverbose=0, severity='INFO'):
         if severity.lower() == 'error':
             s = bcolors.FAIL + s + bcolors.ENDC
 
+    if g_currentProgress and sys.stdout.isatty():
+        sys.stdout.write("\r\033[K")
+        sys.stdout.flush()
+
     if g_logfp:
         g_logfp.write("%s: %s\n" % (severity.upper(), s))
     g_logs.append("%s: [%s] %s" % (g_currentProgress or g_scriptname, severity.upper(), s))
@@ -99,7 +103,7 @@ def progress(rest=None, every=1):
         g_numProgress += 1
         g_currentProgress = rest
         if g_numProgress % every == 0:
-            print("\r% 6d %s " % (g_numProgress, rest), end="")
+            print("\r\033[K% 6d %s " % (g_numProgress, rest), end="")
             sys.stdout.flush()
     else:
         g_currentProgress = ""
@@ -242,10 +246,8 @@ def datestr_to_datetime(s):
     return dt
 
 
-def parse_xdid(path):
-    a = path.rindex('/')
-    b = path.rindex('.')
-    return path[a+1:b]
+def xdid_from_path(path):
+    return os.path.splitext(os.path.basename(path))[0]
 
 
 def parse_pathname(path):
@@ -371,6 +373,9 @@ def parse_tsv(fn, objname=None):
         fp = codecs.open(fn, encoding='utf-8')
         rows = parse_tsv_data(fp.read(), objname)
         return dict((r[0], r) for r in rows)
+    except FileNotFoundError:
+        info("parse_tsv('%s'): file does not exist yet" % fn)
+        return {}
     except Exception as e:
         error("parse_tsv('%s') %s" % (fn, str(e)))
         if g_args.debug:
@@ -382,6 +387,9 @@ def parse_tsv_rows(fn, objname=None):
     try:
         fp = codecs.open(fn, encoding='utf-8')
         return [r for r in parse_tsv_data(fp.read(), objname)]
+    except FileNotFoundError:
+        info("parse_tsv_rows('%s'): file does not exist yet" % fn)
+        return []
     except Exception as e:
         error("parse_tsv_rows('%s'): %s" % (fn, str(e)))
         if g_args.debug:

--- a/xdfile/xdfile.py
+++ b/xdfile/xdfile.py
@@ -480,7 +480,7 @@ def _jsonl_dumps(d):
 
 
 def _load_corpus_cache_file(path):
-    info("loading corpus cache from %s..." % path)
+    info("loading corpus cache from %s (json lib: %s)..." % (path, _json_lib.__name__))
     t0 = time.perf_counter()
     cache = {}
     # binary mode: orjson.loads accepts bytes; json.loads also accepts bytes since 3.6

--- a/xdfile/xdfile.py
+++ b/xdfile/xdfile.py
@@ -7,8 +7,8 @@ import functools
 import re
 import datetime
 
-from .utils import parse_pathname, progress, parse_pubid, find_files, get_args, memoize, parse_xdid
-from .utils import error, warn
+from .utils import parse_pathname, progress, parse_pubid, find_files, get_args, memoize, xdid_from_path
+from .utils import error, warn, info
 
 g_corpus = []  # list of xdfile
 g_all_clues = []  # list of ClueAnswer
@@ -174,6 +174,13 @@ class xdfile:
         if r < 0 or c < 0 or r >= len(self.grid) or c >= len(self.grid[0]):
             return BLOCK_CHAR
         return self.grid[r][c]
+
+    def is_redacted(self):
+        # True when the puzzle's letter cells are all 'X' — typically a contest
+        # puzzle published before answers were released. Useful for excluding
+        # from grid/answer/clue analysis while still counting it in metadata.
+        letters = ''.join(c for row in self.grid for c in row if c not in '#_.')
+        return bool(letters) and all(c == 'X' for c in letters)
 
     def rebus(self):
         """returns rebus dict of only special (non A-Z) characters"""
@@ -428,12 +435,11 @@ def corpus():
 
     args = get_args()
 
+    info("loading corpus from %s..." % args.corpusdir)
     ret = []
 
     for fullfn, contents in find_files(args.corpusdir, ext='.xd'):
         try:
-            progress(fullfn)
-
             xd = xdfile(contents.decode("utf-8"), fullfn)
 
             ret.append(xd)
@@ -443,6 +449,7 @@ def corpus():
                 raise
 
     progress()
+    info("loaded %d puzzles, done" % len(ret))
 
     return ret
 
@@ -453,7 +460,7 @@ def corpus_contents():
     args = get_args()
     ret = {}
     for fullfn, contents in find_files(args.corpusdir, ext='.xd'):
-        xdid = parse_xdid(fullfn)
+        xdid = xdid_from_path(fullfn)
         ret[xdid.lower()] = contents
     return ret
 
@@ -491,15 +498,14 @@ class ClueAnswer:
 
 def clues():
     if not g_all_clues:
-        for xd in corpus():  # r in parse_tsv("clues.tsv", "AnswerClue"):
-            progress(xd.filename)
+        info("extracting clues from %d puzzles..." % len(corpus()))
+        for xd in corpus():
             pubid = xd.publication_id()
             dt = xd.date() or ""
             for pos, clue, answer in xd.iterclues():
                 ca = ClueAnswer(pubid, dt, answer, clue)
                 g_all_clues.append(ca)
-
-        progress()
+        info("extracted %d clues, done" % len(g_all_clues))
 
     return g_all_clues
 

--- a/xdfile/xdfile.py
+++ b/xdfile/xdfile.py
@@ -4,8 +4,15 @@
 import string
 import operator
 import functools
+import os
 import re
 import datetime
+import time
+
+try:
+    import orjson as _json_lib
+except ImportError:
+    import json as _json_lib
 
 from .utils import parse_pathname, progress, parse_pubid, find_files, get_args, memoize, xdid_from_path
 from .utils import error, warn, info
@@ -429,29 +436,142 @@ class xdfile:
         return flipxd
 
 
-# get_args(...) should be called before corpus()
-@memoize
-def corpus():
+def _xd_to_dict(xd):
+    return {
+        'filename': xd.filename,
+        'headers': dict(xd.headers),
+        'grid': list(xd.grid),
+        'notes': xd.notes,
+        'pubid': xd._publication_id,
+        # JSON has no tuples; lists round-trip back to tuples on load
+        'clues': [[list(pos), clue, answer] for pos, clue, answer in xd.clues],
+    }
 
+
+def _dict_to_xd(d):
+    # bypass __init__ (which would re-parse from .xd source); set fields directly
+    xd = xdfile.__new__(xdfile)
+    xd.filename = d['filename']
+    xd.headers = d['headers']
+    xd.grid = d['grid']
+    xd.notes = d['notes']
+    xd._publication_id = d['pubid']
+    xd.clues = [(tuple(pos), clue, answer) for pos, clue, answer in d['clues']]
+    return xd
+
+
+def _resolve_cache_path():
+    """Decide where the corpus JSONL cache lives, or None to disable."""
     args = get_args()
+    if getattr(args, 'corpus_cache_disabled', False):
+        return None
+    if getattr(args, 'corpus_cache', None):
+        return args.corpus_cache
+    base = os.path.basename(args.corpusdir.rstrip('/\\')) or 'corpus'
+    return '.corpus.%s.jsonl' % base
 
-    info("loading corpus from %s..." % args.corpusdir)
-    ret = []
 
-    for fullfn, contents in find_files(args.corpusdir, ext='.xd'):
-        try:
-            xd = xdfile(contents.decode("utf-8"), fullfn)
+def _jsonl_dumps(d):
+    """Serialize one dict to JSON bytes, regardless of whether orjson or stdlib json is in use."""
+    out = _json_lib.dumps(d)
+    if isinstance(out, str):
+        out = out.encode('utf-8')
+    return out
 
-            ret.append(xd)
-        except Exception as e:
-            error("corpus(): %s" % str(e))
-            if args.debug:
-                raise
+
+def _load_corpus_cache_file(path):
+    info("loading corpus cache from %s..." % path)
+    t0 = time.perf_counter()
+    cache = {}
+    # binary mode: orjson.loads accepts bytes; json.loads also accepts bytes since 3.6
+    with open(path, mode='rb') as f:
+        for line in f:
+            xd = _dict_to_xd(_json_lib.loads(line))
+            cache[xd.xdid()] = xd
+            progress(xd.xdid(), every=1000)
+    progress()
+    elapsed = time.perf_counter() - t0
+    info("loaded %d puzzles from cache in %.2fs, done" % (len(cache), elapsed))
+    return cache
+
+
+def _build_corpus_cache(cache_path):
+    """Walk corpusdir, parse each .xd, optionally stream-write JSONL to cache_path."""
+    args = get_args()
+    info("walking corpus from %s..." % args.corpusdir)
+
+    if cache_path:
+        tmp_path = cache_path + '.tmp'
+        cache_fp = open(tmp_path, mode='wb')
+    else:
+        tmp_path = None
+        cache_fp = None
+
+    cache = {}
+    try:
+        for fullfn, contents in find_files(args.corpusdir, ext='.xd'):
+            try:
+                xd = xdfile(contents.decode("utf-8"), fullfn)
+            except Exception as e:
+                error("corpus(): %s" % str(e))
+                if args.debug:
+                    raise
+                continue
+
+            cache[xd.xdid()] = xd
+            if cache_fp:
+                cache_fp.write(_jsonl_dumps(_xd_to_dict(xd)))
+                cache_fp.write(b'\n')
+    finally:
+        if cache_fp:
+            cache_fp.close()
 
     progress()
-    info("loaded %d puzzles, done" % len(ret))
+    info("loaded %d puzzles, done" % len(cache))
 
-    return ret
+    if cache_path and tmp_path:
+        os.replace(tmp_path, cache_path)
+        info("wrote corpus cache to %s" % cache_path)
+
+    return cache
+
+
+# get_args(...) should be called before corpus_cache()
+@memoize
+def corpus_cache():
+    """dict[xdid -> xdfile] for the whole corpus. Uses a JSONL cache when present."""
+    cache_path = _resolve_cache_path()
+    if cache_path is None:
+        info("corpus cache disabled (--no-corpus-cache); walking corpus")
+        return _build_corpus_cache(None)
+    if os.path.exists(cache_path):
+        info("found corpus cache at %s; loading" % cache_path)
+        try:
+            return _load_corpus_cache_file(cache_path)
+        except Exception as e:
+            warn("corpus cache %s unreadable (%s); rebuilding" % (cache_path, e))
+            return _build_corpus_cache(cache_path)
+    info("no corpus cache at %s; building it" % cache_path)
+    return _build_corpus_cache(cache_path)
+
+
+def corpus():
+    return list(corpus_cache().values())
+
+
+def iter_corpus():
+    """Yield xdfile objects: from args.inputs if given, else the full cached corpus.
+
+    Use this in scripts that want to support both:
+      - `script.py -c gxd`              => iterate the whole corpus (uses cache)
+      - `script.py -c gxd one.xd two.xd` => iterate just the named files
+    """
+    args = get_args()
+    if args.inputs:
+        for fn, contents in find_files(*args.inputs, ext='.xd'):
+            yield xdfile(contents.decode('utf-8'), fn)
+    else:
+        yield from corpus_cache().values()
 
 
 # just xdid -> contents
@@ -513,15 +633,9 @@ def clues():
 def get_shelf(path):
     return parse_pathname(path).base.split('-')[0]
 
-@memoize
 def get_xd(xdid):
-    """ Try to load xdfile and return None if error """
-    try:
-        xd = xdfile(corpus_contents()[xdid].decode("utf-8"), xdid)
-    except Exception:
-        # error("get_xd() %s" % str(e))
-        return None
-    return xd
+    """ Try to load xdfile and return None if not in corpus """
+    return corpus_cache().get(xdid)
 
 def num_cells(size):
     """


### PR DESCRIPTION
I did a sort of usability pass through the import pipeline: the 2x- and 3x- series of scripts. 

- fixed some problems with path normalization on windows
- improved performance of a few scripts
- made the logs a little easier to read (fixed issues with \r lines and so on)
- excluded from clue/answer analysis puzzles where every answer is X (i'm calling these "redacted" puzzles).
- added a jsonl cache file to prevent scanning the gxd/ for .xd files. This makes a big difference on my dev machine (minutes per script); smaller on CI.
- fixed a bug where the recent-changed-xdids weren't being considered at all in the clue scripts.
- shortened the recent-changed-xdids window to 1d (30d pulled in way too many changes).

