### PR TITLE
fixes to character encoding during puz to xd conversion

### DIFF
--- a/doc/character-encoding.md
+++ b/doc/character-encoding.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-The .xd format spec ([doc/xd-format.md](xd-format.md)) declares the file is "a simple UTF-8 text file, and can often be 7-bit ASCII clean." In practice, the gxd corpus (94k+ puzzles, ingested over decades from publisher feeds) contains a small fraction of files with byte-level artifacts from at least five different upstream encodings. None of them are inherent to .xd itself — they were inherited from the source .puz / .ipuz / PDF files and propagated through legacy converters.
+The .xd format spec ([doc/xd-format.md](xd-format.md)) declares the file is "a simple UTF-8 text file, and can often be 7-bit ASCII clean." In practice, the gxd corpus (94k+ puzzles, ingested over years from multiple sources) contains a small fraction of files with byte-level artifacts from at least five different upstream encodings. None of them are inherent to .xd itself — they were inherited from the source .puz / .ipuz / PDF files and propagated through legacy converters.
 
 This document catalogues the patterns observed, the diagnostics that distinguish them, and the cleanup pipeline that handles each. It exists because we hit every one of these patterns at least once during a single review pass and had to figure them out from scratch.
 
 The two relevant tools:
 
 - [`xdfile/puz2xd.py`](../xdfile/puz2xd.py) `decode()` — runs at conversion time on every clue/header pulled out of a .puz file. The shared utility lives in [`xdfile/utils.py`](../xdfile/utils.py).
-- [`xdlint.py`](../xdlint.py) rules `XD009` (latin-1 misread of UTF-8) and `XD010` (C1 control mojibake) — run at lint time over .xd files already on disk.
+- [`xdlint.py`](../xdlint.py) rules `XD009` (latin-1 misread of UTF-8) and `XD010` (C1 control [mojibake](https://en.wikipedia.org/wiki/Mojibake)) — run at lint time over .xd files already on disk.
 
 Both implementations are kept in lockstep with each other and with the standalone [`puz2xd-standalone.py`](../puz2xd-standalone.py).
 
@@ -152,7 +152,7 @@ Universal Crossword 2018 has files with `Ã¢ÂÂ™` patterns — a UTF-8 seque
 Em dash (U+2014) appears 839 times across 416 corpus files. It serves at least three distinct purposes, only the first two of which are valid:
 
 1. **Real typography** — `"say it again — I'm outta here"`, attribution dashes (`—Woody Allen`).
-2. **Fill-in-the-blank marker** — `"— Miniver (1942 film classic) ~ MRS"`, `"Persona non — ~ GRATA"`. This is a publisher convention distinct from the spec's `___` (underscore) FITB. Found extensively in Wapost, Eltana, NYTimes corpora.
+2. **Fill-in-the-blank marker** — `"— Miniver (1942 film classic) ~ MRS"`, `"Persona non — ~ GRATA"`. This is a publisher convention distinct from the common ascii-form `___` (triple-underscore) FITB. Found extensively in Wapost, Eltana, NYTimes corpora.
 3. **Mac Roman 'ó' mojibake** — `"Almod—var ~ PEDROS"` should be `Almodóvar`. Mac Roman `0x97 = ó` (cp1252 `0x97 = —`). The legacy converter applied cp1252 indiscriminately, turning Mac Roman accented `ó` bytes into spurious em dashes.
 
 Because of (3), **don't auto-flatten em dashes to `--` corpus-wide**. Doing so would erase the diagnostic signal for the Mac Roman cases. Em dashes that are clearly typography or FITB can be left alone; the suspicious ones (mid-word in proper nouns) need manual review.

--- a/doc/character-encoding.md
+++ b/doc/character-encoding.md
@@ -1,0 +1,270 @@
+# Character Encoding Oddities in .xd
+
+## Status
+
+The .xd format spec ([doc/xd-format.md](xd-format.md)) declares the file is "a simple UTF-8 text file, and can often be 7-bit ASCII clean." In practice, the gxd corpus (94k+ puzzles, ingested over decades from publisher feeds) contains a small fraction of files with byte-level artifacts from at least five different upstream encodings. None of them are inherent to .xd itself — they were inherited from the source .puz / .ipuz / PDF files and propagated through legacy converters.
+
+This document catalogues the patterns observed, the diagnostics that distinguish them, and the cleanup pipeline that handles each. It exists because we hit every one of these patterns at least once during a single review pass and had to figure them out from scratch.
+
+The two relevant tools:
+
+- [`xdfile/puz2xd.py`](../xdfile/puz2xd.py) `decode()` — runs at conversion time on every clue/header pulled out of a .puz file. The shared utility lives in [`xdfile/utils.py`](../xdfile/utils.py).
+- [`xdlint.py`](../xdlint.py) rules `XD009` (latin-1 misread of UTF-8) and `XD010` (C1 control mojibake) — run at lint time over .xd files already on disk.
+
+Both implementations are kept in lockstep with each other and with the standalone [`puz2xd-standalone.py`](../puz2xd-standalone.py).
+
+---
+
+## 1. The fundamental problem: bytes 0x80–0x9F
+
+`.puz` files declare their string encoding in a version flag: pre-v1.4 puzzles are ISO-8859-1 (latin-1); v1.4+ may be UTF-8. In ISO-8859-1, bytes 0x80–0x9F decode to **C1 control codepoints** (U+0080–U+009F) — a band of unassigned/control characters that have no meaning in printable text.
+
+Publishers, however, regularly used those byte slots for printable characters from whichever 8-bit encoding their tooling actually produced (cp1252 on Windows, Mac Roman on Mac, cp437 on DOS-era systems). When puzpy honors the file's declared latin-1 encoding, those bytes survive the trip into Python as literal U+0080–U+009F characters, which then sit untouched in any .xd produced by a naive converter.
+
+So *every* C1 control codepoint in our corpus is mojibake. The question is just which encoding produced the byte.
+
+---
+
+## 2. The encoding families observed
+
+| Family | Where it appears | Diagnostic |
+|---|---|---|
+| **cp1252 (Windows-1252)** | Most common — em dashes, smart quotes, š, Š, ž | C1 byte means a typography char (U+2014 em dash, U+201C/D curly quotes, …) |
+| **Mac Roman** | Older publisher feeds (NYTimes, Boston Globe, King Syndicate) | C1 byte means an accented vowel — most consistently `0x8E = é` |
+| **cp437 (DOS)** | Old Newsday <2002, NYSun 2007, SimonSchuster <2005, NYT 1990s | C1 byte means an accented vowel via DOS code page (0x82 = é, 0x89 = ë) |
+| **UTF-8 misread as latin-1** | Various Reagle (Philadelphia), Universal Crossword, NYT 2013+ | Multi-character runs like `Ã©` (= `é`), `Ãª` (= `ê`), `â` (= `"`) |
+| **PDF Symbol font** | Boston Globe 2009-2013 math clues | Non-standard: byte 0x80 = `°`, byte 0x98 = `÷` (no encoding maps this) |
+
+---
+
+## 3. cp1252 — the default
+
+The vast majority of C1-control mojibake comes from cp1252. The fixer [`xdlint.py`](../xdlint.py) `XD010` defaults to this mapping; the same logic lives in [`xdfile/utils.py`](../xdfile/utils.py) `clean_c1_controls()`.
+
+Reference table for the C1 range in cp1252 (the slots marked `—` are undefined and pass through unchanged):
+
+| Byte | Char | Notes | Byte | Char | Notes |
+|--:|:--|---|--:|:--|---|
+| 0x80 | € | euro / often ambiguous | 0x90 | — |   |
+| 0x81 | — |   | 0x91 | ' | left single quote |
+| 0x82 | ‚ | low single quote | 0x92 | ' | right single quote |
+| 0x83 | ƒ |   | 0x93 | " | left double quote |
+| 0x84 | „ | low double quote | 0x94 | " | right double quote |
+| 0x85 | … | ellipsis | 0x95 | • | bullet |
+| 0x86 | † | dagger | 0x96 | – | en dash |
+| 0x87 | ‡ | double dagger | 0x97 | — | em dash |
+| 0x88 | ˆ |   | 0x98 | ˜ | small tilde |
+| 0x89 | ‰ | per mille | 0x99 | ™ | trademark |
+| 0x8A | Š |   | 0x9A | š |   |
+| 0x8B | ‹ |   | 0x9B | › |   |
+| 0x8C | Œ |   | 0x9C | œ |   |
+| 0x8D | — |   | 0x9D | — |   |
+| 0x8E | Ž | **see §4** | 0x9E | ž |   |
+| 0x8F | — |   | 0x9F | Ÿ |   |
+
+For codepoints undefined in cp1252 (0x81, 0x8D, 0x8F, 0x90, 0x9D), the fixer leaves the codepoint intact rather than guessing — `XD010` still emits the finding so the user can review.
+
+---
+
+## 4. Mac Roman: the U+008E exception
+
+cp1252 says `0x8E = Ž` (Latin capital Z with caron, used in Slavic loanwords). Mac Roman says `0x8E = é`. **Every U+008E in our corpus is `é`, not `Ž`** — Cézanne, José, risqué, Gérard, Cité, entrée. Six confirmed cases, zero exceptions.
+
+The fixer hard-codes this as `_CP1252_OVERRIDES[chr(0x8E)] = "é"`. This is the only codepoint where we override cp1252 systematically.
+
+Other Mac Roman vowels (0x87 = á, 0x88 = à, 0x9A = ö, etc.) overlap less catastrophically with cp1252's Slavic letters and special chars (š, Š, ž), and the cp1252 default tends to produce the right answer there. The XD010 finding message lists the Mac Roman candidate alongside cp1252 so the user can spot exceptions.
+
+---
+
+## 5. cp437/DOS: the older publishers
+
+Some older publisher feeds (Newsday late-1990s/early-2000s, NYSun 2007, SimonSchuster 2003-2004, NYT 1990s, NYT 2009 stragglers) came from a DOS-era pipeline where bytes 0x80–0x9F follow code page 437 — accented vowels at slots that cp1252 reserves for typography:
+
+| Byte | cp1252 | cp437 | Likely intent |
+|--:|:--|:--|---|
+| 0x82 | ‚ | é | **almost always é in this corpus** |
+| 0x83 | ƒ | â | â (rare but seen in `grâce`) |
+| 0x85 | … | à | à (Pietà) — but also legit ellipsis cases |
+| 0x86 | † | å | seen as `á` in `González` (so likely a different mojibake path) |
+| 0x87 | ‡ | ç | cases inconsistent — saw a `Pietà` where it should have been à |
+| 0x89 | ‰ | ë | ë (Zoë) |
+| 0x8A | Š | è | è (meunière) — but Š is also legit (Špilberk) |
+| 0x8B | ‹ | ï | rare |
+| 0x9B | › | ¢ | rare |
+
+The fixer does **not** auto-handle these — cp1252 is right for most C1 occurrences, and per-publisher detection isn't reliable enough to swap defaults. Instead, the [XD010 finding message](../xdlint.py) shows all three candidates (cp1252, Mac Roman, cp437):
+
+```
+C1 control U+0082 at col 12 (cp1252: '‚', Mac Roman: 'Ç', cp437: 'é')
+```
+
+The handful of files needing cp437 (~12 files, ~17 character-edits) should be fixed by hand or with a one-off targeted script. They are listed in the project's commit history under the "char encoding cleanup pass" commits.
+
+---
+
+## 6. UTF-8 misread as latin-1
+
+A different kind of mojibake: a UTF-8-encoded byte sequence got read by an upstream tool as ISO-8859-1, producing two- or three-character latin-1 runs. Three sub-patterns:
+
+### 6a. Single-step (`Ãª` → `ê`)
+
+A UTF-8 byte pair `\xc3\xXX` (encoding U+00C0–U+00FF, the Latin supplement) read as latin-1 produces `Ã` (U+00C3) + a continuation byte interpreted as U+0080–U+00BF. Re-encoding the run as latin-1 and decoding as UTF-8 reverses the corruption.
+
+```
+'Ãª' → bytes \xc3\xaa → UTF-8 decode → 'ê'
+'Ã©' → bytes \xc3\xa9 → UTF-8 decode → 'é'
+'Â°' → bytes \xc2\xb0 → UTF-8 decode → '°'
+```
+
+This is what `XD009` (`latin1-utf8-mojibake`) catches. 67 instances across 51 files in the corpus.
+
+False-positive risk is low because real latin-1 text rarely has `Ã`/`Â` followed by a U+0080–U+00BF char — French `Âge`, `RÂLE` etc. have ASCII letters after the `Â`, which fall outside the regex range.
+
+### 6b. Two-step smart-quote trailers (`` → `"`)
+
+For UTF-8 codepoints in the U+2000–U+27FF block (smart quotes, dashes), the encoding is `\xe2\x80\xXX`. When the leading `\xe2\x80` was either dropped entirely or replaced by an upstream processor (often with a straight ASCII `"`), what survives is just the trailing byte at U+0080–U+009F:
+
+```
+'dont'      → bytes \xe2\x80\x99 → '’' (right curly) → "don't"
+'hi' → bytes \xe2\x80\x9c, \xe2\x80\x9d → '"hi"'
+```
+
+`XD010`'s UTF-8 trailer pass handles these by prepending `\xe2` before re-decoding. Also handles the variant where `\xe2` survived as latin-1 `â`:
+
+```
+'âs' → bytes \xe2\x80\x99 → "'s"
+```
+
+### 6c. Orphan trailers (`"` → `"`)
+
+A specific, very common variant of 6b: smart quotes around a phrase like `\xe2\x80\x9c hello \xe2\x80\x9d` had each `\xe2\x80` lead pair replaced with a straight ASCII `"`, but the `\x9c` / `\x9d` trailer byte was left orphaned next to the straight quote. Pattern uniformly observed: every U+009C / U+009D in the corpus appears immediately after a `"` (336/336 occurrences, no exceptions).
+
+`XD010` strips the orphan trailer when adjacent to a straight quote.
+
+### 6d. Triple-encoded mojibake
+
+Universal Crossword 2018 has files with `Ã¢ÂÂ™` patterns — a UTF-8 sequence that was misread, re-encoded, misread again, and re-encoded once more. Currently the XD009 pass + XD010 trailer pass collapses *most* of this correctly (because XD009 turns `Â` into U+0080, which then matches XD010's trailer regex), but stubborn residue remains. Out of scope for the auto-fixers; hand-edit if it bothers you.
+
+---
+
+## 7. Em dash: not just typography
+
+Em dash (U+2014) appears 839 times across 416 corpus files. It serves at least three distinct purposes, only the first two of which are valid:
+
+1. **Real typography** — `"say it again — I'm outta here"`, attribution dashes (`—Woody Allen`).
+2. **Fill-in-the-blank marker** — `"— Miniver (1942 film classic) ~ MRS"`, `"Persona non — ~ GRATA"`. This is a publisher convention distinct from the spec's `___` (underscore) FITB. Found extensively in Wapost, Eltana, NYTimes corpora.
+3. **Mac Roman 'ó' mojibake** — `"Almod—var ~ PEDROS"` should be `Almodóvar`. Mac Roman `0x97 = ó` (cp1252 `0x97 = —`). The legacy converter applied cp1252 indiscriminately, turning Mac Roman accented `ó` bytes into spurious em dashes.
+
+Because of (3), **don't auto-flatten em dashes to `--` corpus-wide**. Doing so would erase the diagnostic signal for the Mac Roman cases. Em dashes that are clearly typography or FITB can be left alone; the suspicious ones (mid-word in proper nouns) need manual review.
+
+The `XD010` finding message shows `cp1252: '—', Mac Roman: 'ó'` for U+0097 cases that haven't yet been fixed, so future C1-control reviews surface this distinction.
+
+---
+
+## 8. Boston Globe Symbol-font glyphs
+
+Two files (`bg2010-03-28.xd` and `bg2012-04-29.xd`) contain U+0098 in math contexts that wants `÷`:
+
+```
+D109. MDLX ÷ X ~ CLVI            (1560 ÷ 10 = 156, in Roman numerals)
+D55.  3 ÷ cosine? ~ TRIPLESECANT (3/cosine = 3 × secant = "triple secant")
+```
+
+The byte 0x98 → `÷` mapping doesn't match any standard 8-bit encoding (cp1252: ˜, Mac Roman: ò). This appears to be a Boston Globe internal Symbol-font convention that bled through the .puz pipeline. With only two corpus instances, hand-edit was the right answer; no rule was added.
+
+Similar artifacts appeared at byte 0x80 in BG 2009-2011 files for `°` (`90° on a compass`), where neither cp1252 (`€`) nor Mac Roman (`Ä`) matches. The `XD010` skip-list refuses to auto-fix U+0080 and U+0098 single-character occurrences for exactly this reason.
+
+---
+
+## 9. The decode pipeline (puz2xd.decode)
+
+[`xdfile/puz2xd.py`](../xdfile/puz2xd.py) `decode()` runs at conversion time on every clue, header, and metadata field pulled from a .puz. Order of operations:
+
+1. **Strip orphan `Â`** before a C1 control: `\xc2\xXX` UTF-8 misread as latin-1 produces `Â + control`. Drop the `Â` so `clean_c1_controls` handles the trailer.
+2. **NBSP collapse**: `\xc2\xa0` (UTF-8 NBSP read as latin-1) and standalone `\xa0` → space.
+3. **Targeted UTF-8 fix**: `\xc3\xa8` (`Ã¨`) → `è`. (Subsumed by `clean_latin1_utf8_mojibake` but kept explicit for clarity / backward-compat with old test cases.)
+4. **Mac Roman curly quotes**: `\xd3` → `"`, `\xd4` → `"`.
+5. **`clean_latin1_utf8_mojibake`**: §6a — `Ã/Â + cont byte` → re-decoded UTF-8 char.
+6. **`clean_c1_controls`**: §3, §4 — UTF-8 trailer reconstruction → U+008E override → cp1252 default with U+0080/U+0098 skipped.
+7. **ASCII typography flattening**: curly quotes → ASCII, ellipsis → `...`. Em dash kept as Unicode (matches existing corpus convention).
+8. **URL unquote, HTML entity unescape, whitespace collapse** — pre-existing legacy steps.
+
+The two lossy bulk replacements that the legacy decode used to do — `\xc3\x82 → ""` and `\xc2 → " "` — are dropped. They corrupted legitimate French text (real `Â`, `Ã` in proper nouns) trying to clean up a small class of UTF-8 leftovers. The new pipeline only touches `Â` / `Ã` when followed by a continuation byte (a clear UTF-8 mojibake signal).
+
+---
+
+## 10. The lint rules
+
+| Code | Severity | Catches | Auto-fix |
+|---|---|---|---|
+| `XD009` | error | latin-1 misread of UTF-8 (`Ãª`, `Ã©`, `Ã³`, etc.) | yes |
+| `XD010` | error | C1 control codepoints (U+0080–U+009F) | partial |
+
+`XD010`'s fixer runs four passes:
+
+1. UTF-8 trailer reconstruction (§6b)
+2. Orphan smart-quote trailer strip (§6c)
+3. Per-codepoint overrides (currently just U+008E → é, §4)
+4. cp1252 default, with U+0080 and U+0098 skipped (§5, §8) and undefined cp1252 slots passed through (§3)
+
+The finding messages list candidates from cp1252, Mac Roman, and cp437 so a reviewer can pick the right answer when an auto-fix can't.
+
+`XD009` runs **before** `XD010` in the fix order — see [`FIX_ORDER`](../xdlint.py). This matters for triple-mojibake cases (§6d): `Â` collapses to `` after XD009, which XD010's trailer pass then reconstructs to `"`.
+
+---
+
+## 11. Frequency in the corpus
+
+| Pattern | File count | Character count |
+|---|---:|---:|
+| C1 control mojibake (XD010 catches) | ~150 | ~564 |
+| of which: U+0097 (em dash + Mac Roman ó) | ~50 | 98 |
+| of which: U+009D (orphan smart quote close) | ~150 | 364 |
+| of which: U+008E (Mac Roman é override) | 6 | 6 |
+| of which: U+0080 / U+0098 (skipped, manual) | 2 | 2 |
+| latin-1 misread of UTF-8 (XD009 catches) | 51 | 67 |
+| cp437 typography residue (manual hand-edit) | 12 | 17 |
+| Triple-encoded mojibake (Universal 2018) | ~5 | varied |
+
+After running `--fix` with both rules enabled and applying the 17 hand-edits (see [§12](#12-the-residue-list)), the corpus is clean of C1 controls and latin-1-misread-UTF-8 mojibake.
+
+---
+
+## 12. The residue list
+
+Cases where auto-fix doesn't help and hand-editing is the right answer:
+
+| File | Char | Should be | Why |
+|---|---|---|---|
+| `bg2010-03-28.xd:166` | `` (math context) | `÷` | PDF Symbol font, no encoding match (§8) |
+| `bg2012-04-29.xd:138` | `` (math context) | `÷` | PDF Symbol font (§8) |
+| `bg2009-06-07.xd:32`  | `` (compass) | `°` | PDF Symbol artifact, neither encoding matches |
+| `bg2011-05-15.xd:73`  | `` (Réaumur) | `°` | Same as above |
+| `nw1999-03-01.xd:88`  | `‚` (Soufflé) | `é` | cp437 0x82 (§5) — fixed |
+| `nys2007-04-02.xd:27` | `‚` (También) | `é` | cp437 0x82 — fixed |
+| `nys2007-04-12.xd:29` | `‚` (Kertész) | `é` | cp437 0x82 — fixed |
+| `ss2003-12-08.xd:46`  | `‚` (Café) | `é` | cp437 0x82 — fixed |
+| `ss2004-03-01.xd:81`  | `‚` (entrées) | `é` | cp437 0x82 — fixed |
+| `ss2004-08-30.xd:46`  | `‚` (Café) | `é` | cp437 0x82 — fixed |
+| `nyt1997-06-29.xd:57` | `‚` (grâce) | `â` | cp437 0x82, but context wants `â` not `é` |
+| `nys2007-04-06.xd:88` | `‰` (Zoë) | `ë` | cp437 0x89 — fixed |
+| `nyt2009-01-12.xd:45` | `Ž` (Risqué) | `é` | Mac Roman 0x8E that survived (the override only kicks in pre-fix) — fixed |
+| `pk2015-02-08.xd:92`  | `‡` (Pietà) | `à` | OCR/encoding error, not standard — fixed |
+| `nw2001-02-13.xd:65`  | `†` (González) | `á` | OCR/encoding error — fixed |
+| `pk2005-05-01.xd:123` | `Œ` (`Œteam"`) | `"` (open) | Mojibake of left curly quote — fixed |
+| `bg2009-03-15.xd:153` | `‚` (`suppose‚...`) | (delete) | Stray char, not a real letter — fixed |
+| `ss2004-02-16.xd:53`  | `Š` (meunière) | `è` | cp437 0x8A (Mac Roman 0x8A is also è) — fixed |
+| `nyt2005-01-30a.xd:1` | `†` (`2005† SMOOTH MOVE`) | `:` | Title separator — fixed |
+
+The `Š` characters in `gxd/indie/bequigley/beq-0424.xd:44` and `beq-1390.xd:61` (`Špilberk Castle`) are **legitimate** cp1252 — leave alone.
+
+---
+
+## 13. Recommendations for new ingestion
+
+1. **Use the shared `clean_c1_controls()` and `clean_latin1_utf8_mojibake()` from `xdfile.utils`.** Don't recreate per-byte hand-coded lists.
+2. **Don't blanket-strip `Â` (U+00C2) or `Ã` (U+00C3).** They appear in real French/Portuguese text. Only strip when followed by a continuation byte (a UTF-8 mojibake signal).
+3. **Don't auto-fix U+0080 or U+0098 single-character occurrences.** Their cp1252 mappings (`€`, `˜`) are usually wrong in this corpus (PDF Symbol artifacts for `°`, `÷`).
+4. **Audit `xdfile/ccxml2xd.py`, `xdfile/xwordinfo2xd.py`, `xdfile/ujson2xd.py`** if a new source format starts producing mojibake. They currently hard-assume UTF-8 and skip the cleanup pipeline.
+5. **Run XD009 + XD010 routinely.** Both are in the default `--fix` order. They catch mojibake from any source format, not just .puz.
+6. **Keep `puz2xd.py` and `puz2xd-standalone.py` in lockstep.** The standalone script duplicates `clean_c1_controls`/`clean_latin1_utf8_mojibake` so it can run without the `xdfile` package installed; both must be updated together.

--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -27,22 +27,70 @@ HEADER_ORDER = ['title', 'author', 'editor', 'copyright', 'number', 'date',
 NON_ANSWER_CHARS = [BLOCK_CHAR, OPEN_CHAR]  # UNKNOWN_CHAR is a wildcard answer character
 
 
+# --- C1-control cleanup (kept in lockstep with xdfile.utils.clean_c1_controls
+# and the XD010 fixer in xdlint.py). Standalone duplicates this so the script
+# can run without the xdfile package. ---
+_CP1252_OVERRIDES = {chr(0x8e): "é"}  # cp1252's 'Ž' is wrong in our corpus
+_CP1252_SKIP_SINGLE = {chr(0x80), chr(0x98)}  # too ambiguous to auto-decide
+_C1_RE = re.compile(r"[\x80-\x9f]")
+_UTF8_TRAILER_RE = re.compile(r"â?\x80[\x80-\x9f]")
+_LATIN1_UTF8_RE = re.compile(r"[\xc2\xc3][\x80-\xbf]")
+
+
+def clean_latin1_utf8_mojibake(s):
+    def repl(m):
+        try:
+            return m.group(0).encode('latin-1').decode('utf-8')
+        except UnicodeDecodeError:
+            return m.group(0)
+    return _LATIN1_UTF8_RE.sub(repl, s)
+
+
+def clean_c1_controls(s):
+    def utf8_repl(m):
+        s = m.group(0)
+        bs = s.encode("latin-1")
+        if not bs.startswith(b"\xe2"):
+            bs = b"\xe2" + bs
+        try:
+            return bs.decode("utf-8")
+        except UnicodeDecodeError:
+            return s
+    s = _UTF8_TRAILER_RE.sub(utf8_repl, s)
+
+    def repl(m):
+        ch = m.group(0)
+        if ch in _CP1252_OVERRIDES:
+            return _CP1252_OVERRIDES[ch]
+        if ch in _CP1252_SKIP_SINGLE:
+            return ch
+        try:
+            return ch.encode("latin-1").decode("cp1252")
+        except UnicodeDecodeError:
+            return ch
+    return _C1_RE.sub(repl, s)
+
+
 def decode(s):
-    s = s.replace('\x92', "'")
-    s = s.replace('\xc2\x92', "'")
-    s = s.replace('\xc2\xa0', ' ')  # UTF-8 NBSP double-decoded as latin-1
-    s = s.replace('\xc3\x82',"")
-    s = s.replace('\xc3\xa8',"è") # +A5. Crème de la crème ~ ELITE
-    s = s.replace('\xe0','à') # -A49. Do the seemingly impossible, à la Jesus ~ WALKONWATER
-    s = s.replace('\xc2', " ") # Change rest of 0xC2 to 0x20
-    s = s.replace('\xa0'," ")
-    s = s.replace('\x93', '"')
-    s = s.replace('\x94', '"')
-    s = s.replace('\x97', "—")
-    s = s.replace('\x85', '...')
-    s = s.replace('\x86', '†')
-    s = s.replace('\xd3','"')
-    s = s.replace('\xd4','"')
+    # 'Â' (U+00C2) before a C1 control: \xc2\xXX UTF-8 misread as latin-1.
+    # Strip the orphan 'Â' so clean_c1_controls handles the trailer.
+    s = re.sub(r'Â([\x80-\x9f])', r'\1', s)
+    # UTF-8 NBSP read as latin-1 -> 'Â\xa0'; then any remaining NBSPs.
+    s = s.replace('\xc2\xa0', ' ')
+    s = s.replace('\xa0', ' ')
+    # \xc3\xa8 UTF-8 (è) misread as latin-1 -> 'Ã¨'. Targeted replacement.
+    s = s.replace('Ã¨', 'è')
+    # MacRoman left/right curly double quotes.
+    s = s.replace('\xd3', '"')
+    s = s.replace('\xd4', '"')
+    s = clean_latin1_utf8_mojibake(s)
+    s = clean_c1_controls(s)
+    # ASCII typography convention (corpus keeps em dash, flattens the rest).
+    s = s.translate(str.maketrans({
+        '‘': "'", '’': "'",
+        '“': '"', '”': '"',
+        '…': '...',
+    }))
     s = urllib.parse.unquote(s)
     s = html.unescape(s)
     # Remove spurious semicolons from invalid HTML entity refs

--- a/xdfile/puz2xd.py
+++ b/xdfile/puz2xd.py
@@ -14,7 +14,7 @@ import urllib.error
 import time
 
 import xdfile
-from .utils import warn
+from .utils import warn, clean_c1_controls, clean_latin1_utf8_mojibake
 
 
 def reparse_date(s):
@@ -24,21 +24,35 @@ def reparse_date(s):
 
 
 def decode(s):
-    s = s.replace('\x92', "'")
-    s = s.replace('\xc2\x92', "'")
-    s = s.replace('\xc2\xa0', ' ')  # UTF-8 NBSP double-decoded as latin-1
-    s = s.replace('\xc3\x82',"")
-    s = s.replace('\xc3\xa8',"è") # +A5. Crème de la crème ~ ELITE
-    s = s.replace('\xe0','à') # -A49. Do the seemingly impossible, à la Jesus ~ WALKONWATER
-    s = s.replace('\xc2', " ") # Change rest ot 0xC2 to 0x20
-    s = s.replace('\xa0'," ")
-    s = s.replace('\x93', '"')
-    s = s.replace('\x94', '"')
-    s = s.replace('\x97', "—")
-    s = s.replace('\x85', '...')
-    s = s.replace('\x86', '†')
-    s = s.replace('\xd3','"')
-    s = s.replace('\xd4','"')
+    # UTF-8-encoded characters read as latin-1 surface as 'Â' + trailing
+    # byte. Strip the orphan 'Â' before a C1 control (then clean_c1_controls
+    # handles the trailer). E.g. .puz bytes \xc2\x92 (UTF-8 U+0092) read as
+    # latin-1 -> 'Â' -> '' -> "'".
+    s = re.sub(r'Â([\x80-\x9f])', r'\1', s)
+    # UTF-8 NBSP read as latin-1 surfaces as 'Â\xa0'; collapse to space.
+    s = s.replace('\xc2\xa0', ' ')
+    s = s.replace('\xa0', ' ')
+    # \xc3\xa8 = UTF-8 byte sequence for U+00E8 (è) misread as latin-1 ('Ã¨').
+    # Targeted because real 'Ã¨' is unusual in puzzle text.
+    s = s.replace('Ã¨', 'è')
+    # MacRoman left/right curly double quotes.
+    s = s.replace('\xd3', '"')
+    s = s.replace('\xd4', '"')
+    # UTF-8 latin-supplement bytes (\xc3\xXX, \xc2\xXX) misread as latin-1
+    # leave 'Ã'/'Â' + continuation byte. Re-decode before C1 cleanup so any
+    # 'Â' + C1 sequence collapses cleanly into the C1 path below.
+    s = clean_latin1_utf8_mojibake(s)
+    # Systematic C1-control cleanup (cp1252 + Mac Roman + UTF-8 trailers).
+    # Replaces the per-byte hand-coded list this function used to carry.
+    s = clean_c1_controls(s)
+    # The corpus convention is ASCII typography (em dash is the lone Unicode
+    # exception, matching the legacy `\x97 -> "—"` mapping). Flatten the
+    # other smart-typography chars that clean_c1_controls produced.
+    s = s.translate(str.maketrans({
+        '‘': "'", '’': "'",  # curly single quotes
+        '“': '"', '”': '"',  # curly double quotes
+        '…': '...',               # horizontal ellipsis
+    }))
     s = urllib.parse.unquote(s)
     s = html.unescape(s)
     # Remove spurious semicolons from invalid HTML entity refs

--- a/xdfile/tests/test_puz2xd_decode.py
+++ b/xdfile/tests/test_puz2xd_decode.py
@@ -1,0 +1,134 @@
+"""decode() pipeline tests using synthetic mojibake strings drawn from
+real corpus cases.
+
+Each input is the literal Python string that puzpy would produce after
+decoding a .puz file with the relevant byte sequence. We test decode()
+directly rather than through a .puz round-trip because puzpy is
+well-tested by its own maintainers; the interesting logic is what
+decode() does with the resulting string. This also keeps the tests
+runnable in CI without shipping copyrighted .puz binaries.
+
+Each case's comment cites the corpus .xd file the bytes came from, so
+future maintainers can cross-reference. See doc/character-encoding.md
+for the full taxonomy of mojibake patterns these tests cover.
+"""
+from xdfile.puz2xd import decode
+
+
+# Each case: (input_with_mojibake, expected_output, comment).
+# Input is what puzpy returns after decoding ISO-8859-1 .puz bytes.
+CASES = [
+    # ---- U+008E Mac Roman override (cp1252 says 'Ž', corpus wants 'é') ----
+    # gxd/bostonglobe/2015/bg2015-03-22.xd:109 — bg150322.puz
+    ("Shortstop Jos\x8e", "Shortstop José"),
+    # gxd/king/2008/pk2008-07-20.xd:124 — pk080720.puz
+    ("G\x8erard Depardieu film", "Gérard Depardieu film"),
+    # gxd/newsday/2005/nw2005-03-08.xd:69 — nw050308.puz
+    ("Popular banquet entr\x8ee", "Popular banquet entrée"),
+
+    # ---- cp1252 default for the šŠž block ----
+    # gxd/wapost/2012/wap2012-03-04.xd:44 — pp120304.puz
+    ("Ni\x9a natives", "Niš natives"),
+    # gxd/indie/bequigley/beq-0424.xd:44 — Špilberk Castle (cp1252 Š is correct)
+    ("\x8apilberk Castle", "Špilberk Castle"),
+    # Serbian "Bože pravde" (national anthem)
+    ("Bo\x9ee pravde", "Bože pravde"),
+
+    # ---- UTF-8 smart-quote trailer reconstruction ----
+    # gxd/philadelphia/2014/pi2014-01-12.xd — pi140112.puz
+    # Original UTF-8 bytes \xe2\x80\x9c..\xe2\x80\x9d misread as latin-1
+    # produces 'â' + U+0080 + U+009C/D. Reconstructed and then ASCII-flattened
+    # to straight quotes by the typography pass.
+    ("Trapped, with \xe2\x80\x9cup\xe2\x80\x9d", 'Trapped, with "up"'),
+    # Variant: leading 'â' (\xe2 misread) was already collapsed upstream,
+    # leaving just the C1 trailer pair.
+    ("\x80\x9chello\x80\x9d", '"hello"'),
+    # Right curly single quote (apostrophe)
+    ("don\xe2\x80\x99t", "don't"),
+
+    # ---- Em dash (cp1252 0x97) ----
+    # gxd/avclub/2013/avc2013-07-03.xd:73
+    ("Eja\x97wait", "Eja—wait"),
+
+    # ---- Latin-1 misread of UTF-8 (XD009-class) ----
+    # gxd/crossynergy/2015/cs2015-03-04.xd:73 — should be tête
+    ("\"___ t\xc3\xaate\" lyric", "\"___ tête\" lyric"),
+    # gxd/avclub/2016/avc2016-05-25.xd:71 — Ingénue
+    ("Ing\xc3\xa9nue", "Ingénue"),
+    # Multiple in one line
+    ("M\xc3\xa1laga and Caf\xc3\xa9", "Málaga and Café"),
+    # 'Ã´' (= ô) in Côte / Rhône
+    ("C\xc3\xb4te d'Azur", "Côte d'Azur"),
+
+    # ---- Triple-encoded mojibake collapses correctly ----
+    # gxd/universal/2018/up2018-07-12.xd-style: 'â' (U+00E2) + C1 trailer
+    # pair, where the leading 'â' is itself a UTF-8 round-trip artifact.
+    ("Christian\xe2\x80\x99s book", "Christian's book"),
+
+    # ---- Clean text passes through ----
+    ("Normal clue text", "Normal clue text"),
+    ("café", "café"),
+    # Real French 'Â' / 'Ã' must NOT be touched by XD009-class fix.
+    ("Âge moyen", "Âge moyen"),
+    ("RÂLE", "RÂLE"),
+    ("São Paulo", "São Paulo"),
+]
+
+
+def test_decode_pipeline():
+    for input_text, expected in CASES:
+        actual = decode(input_text)
+        assert actual == expected, (
+            f"decode({input_text!r}) = {actual!r}, expected {expected!r}"
+        )
+
+
+def test_decode_skips_ambiguous_u0080():
+    # gxd/bostonglobe/2009/bg2009-06-07.xd:32 — the "90° on a compass" case.
+    # cp1252 says U+0080 = '€' but corpus wants '°' (PDF Symbol artifact).
+    # decode() must NOT auto-introduce '€'; the codepoint is left for the
+    # XD010 lint rule to surface for manual review.
+    out = decode("90\x80 on a compass")
+    assert "90€" not in out
+    assert "\x80" in out  # left intact
+
+
+def test_decode_skips_ambiguous_u0098():
+    # bg2010-03-28.xd:166 / bg2012-04-29.xd:138 — math contexts wanting '÷'.
+    # Neither cp1252 ('˜') nor Mac Roman ('ò') is right; left for manual fix.
+    out = decode("MDLX \x98 X")
+    assert "˜" not in out
+    assert "ò" not in out
+    assert "\x98" in out
+
+
+def test_decode_undefined_cp1252_passes_through():
+    # cp1252 has 5 undefined slots: 0x81, 0x8D, 0x8F, 0x90, 0x9D. They're
+    # left intact rather than guessed; XD010 lint surfaces them.
+    for cp in (0x81, 0x8d, 0x8f, 0x90, 0x9d):
+        s = "x" + chr(cp) + "y"
+        out = decode(s)
+        assert chr(cp) in out, f"U+{cp:04X} should pass through, got {out!r}"
+
+
+def test_decode_strips_orphan_quote_trailer():
+    # Specifically NOT something decode() handles directly — orphan U+009C
+    # / U+009D after a straight " is XD010-fixer territory (the .xd-level
+    # cleanup, not the puz-conversion pipeline). Document that here so a
+    # future change doesn't accidentally start handling it in decode().
+    out = decode('"Beyond the Sea"\x9d')
+    assert "\x9d" in out  # decode passes it through; XD010 strips it later
+
+
+def test_decode_no_orphan_a_circumflex_strip():
+    # Legacy decode() blindly stripped 'Â' (U+00C2), corrupting real French.
+    # The new pipeline only strips 'Â' when followed by a C1 control (a
+    # UTF-8 mojibake signal).
+    assert decode("Île-de-France") == "Île-de-France"
+    assert decode("RÂLE") == "RÂLE"
+
+
+def test_decode_collapses_nbsp():
+    # \xc2\xa0 = UTF-8 NBSP read as latin-1; \xa0 = bare NBSP. Both -> space.
+    assert decode("foo\xc2\xa0bar") == "foo bar"
+    assert decode("foo\xa0bar") == "foo bar"

--- a/xdfile/tests/test_utils.py
+++ b/xdfile/tests/test_utils.py
@@ -11,3 +11,64 @@ def test_find_files():
     for fullfn, contents in mygen:
         # It should throw out anything starting with '.'
         assert not fullfn.startswith('.')
+
+def test_clean_c1_controls_cp1252_default():
+    # U+0097 -> em dash, U+0091 -> left smart quote, U+009A -> š
+    assert utils.clean_c1_controls("emdash") == "em—dash"
+    assert utils.clean_c1_controls("hi") == "‘hi’"
+    assert utils.clean_c1_controls("Ni") == "Niš"
+
+def test_clean_c1_controls_macroman_e_acute_override():
+    # U+008E is Mac Roman é in our corpus, not cp1252's Ž.
+    assert utils.clean_c1_controls("Czanne") == "Cézanne"
+    assert utils.clean_c1_controls("Jos") == "José"
+
+def test_clean_c1_controls_skips_ambiguous_single():
+    # U+0080 and U+0098 are too ambiguous (° vs €, ÷ vs ˜).
+    # Caller must resolve manually; clean_c1_controls leaves them alone.
+    assert utils.clean_c1_controls("90 compass") == "90 compass"
+    assert utils.clean_c1_controls("3  cosine") == "3  cosine"
+
+def test_clean_c1_controls_utf8_trailer_lead_dropped():
+    # \u0080 + C1 = trailing bytes of \xe2\x80\xXX with lead byte lost.
+    assert utils.clean_c1_controls("hi") == "“hi”"
+    assert utils.clean_c1_controls("dont") == "don’t"
+
+def test_clean_c1_controls_utf8_trailer_lead_as_a_circumflex():
+    # When \xe2 survived as latin-1 'â', strip and reconstruct the
+    # original UTF-8 character.
+    assert utils.clean_c1_controls("âhiâ") == "“hi”"
+    assert utils.clean_c1_controls("donât") == "don’t"
+
+def test_clean_c1_controls_undefined_cp1252_passes_through():
+    # 5 codepoints are undefined in cp1252; they're left alone for
+    # manual resolution (XD010 finding still flags them).
+    for cp in (0x81, 0x8d, 0x8f, 0x90, 0x9d):
+        s = "x" + chr(cp) + "y"
+        assert utils.clean_c1_controls(s) == s, f"U+{cp:04X} should pass through"
+
+def test_clean_c1_controls_no_changes_for_clean_text():
+    assert utils.clean_c1_controls("normal clue text") == "normal clue text"
+    assert utils.clean_c1_controls("Café") == "Café"
+
+def test_clean_latin1_utf8_mojibake_lowercase_e_circumflex():
+    # 'Ãª' = bytes \xc3\xaa (UTF-8 for 'ê') misread as latin-1.
+    assert utils.clean_latin1_utf8_mojibake("tÃªte") == "tête"
+
+
+def test_clean_latin1_utf8_mojibake_lowercase_e_acute():
+    assert utils.clean_latin1_utf8_mojibake("IngÃ©nue") == "Ingénue"
+
+
+def test_clean_latin1_utf8_mojibake_a_circumflex_only_flagged_with_cont_byte():
+    # Real 'Â' followed by ASCII ('Âge') must NOT be touched. The latin-1
+    # encoding of 'Âg' is \xc2\x67 which fails UTF-8 decode anyway, but
+    # the regex should not even match because 0x67 is outside U+0080-U+00BF.
+    assert utils.clean_latin1_utf8_mojibake("Âge") == "Âge"
+    assert utils.clean_latin1_utf8_mojibake("RÂLE") == "RÂLE"
+
+
+def test_clean_latin1_utf8_mojibake_no_change_for_clean_text():
+    assert utils.clean_latin1_utf8_mojibake("café") == "café"
+    assert utils.clean_latin1_utf8_mojibake("plain ascii") == "plain ascii"
+

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -44,6 +44,80 @@ def space_with_nbsp(text):
     """ Replace spaces with ;nbsp; """
     return text.replace(' ', '&nbsp;')
 
+
+# C1 control codepoints (U+0080..U+009F) appear in puzzle text whenever bytes
+# from a non-latin-1 source were decoded as latin-1. Most are cp1252 mojibake
+# (em dashes, smart quotes, š), but a handful are Mac Roman ('é' for U+008E),
+# UTF-8 trailers (\xe2\x80\xXX with the lead byte lost or surviving as 'â'),
+# or symbols neither encoding represents (°, ÷). Kept in lockstep with the
+# XD010 fixer in xdlint.py.
+_CP1252_OVERRIDES = {chr(0x8e): "é"}  # cp1252's 'Ž' is wrong in our corpus
+_CP1252_SKIP_SINGLE = {chr(0x80), chr(0x98)}  # too ambiguous to auto-decide
+_C1_RE = re.compile(r"[\x80-\x9f]")
+_UTF8_TRAILER_RE = re.compile(r"â?\x80[\x80-\x9f]")
+
+
+# UTF-8 byte sequence \xc2\xXX or \xc3\xXX (encoding U+0080-U+00FF, the
+# latin supplement) misread as latin-1 produces 'Â' or 'Ã' followed by a
+# char in U+0080-U+00BF (the continuation-byte range). Re-encoding as
+# latin-1 and decoding as UTF-8 reverses the corruption. Common in puzzle
+# text from sources where UTF-8 .puz contents got decoded as ISO-8859-1
+# by puzpy. Real text rarely has 'Â'/'Ã' followed by a U+0080-U+00BF
+# char, so the false-positive rate is low.
+_LATIN1_UTF8_RE = re.compile(r'[\xc2\xc3][\x80-\xbf]')
+
+
+def clean_latin1_utf8_mojibake(s: str) -> str:
+    """Re-decode UTF-8 byte pairs that were misread as latin-1. Catches
+    accented vowels and other latin-supplement characters that survived
+    a wrong-encoding round-trip (e.g. 'Ãª' -> 'ê', 'Ã©' -> 'é')."""
+    def repl(m):
+        try:
+            return m.group(0).encode('latin-1').decode('utf-8')
+        except UnicodeDecodeError:
+            return m.group(0)
+    return _LATIN1_UTF8_RE.sub(repl, s)
+
+
+def clean_c1_controls(s: str) -> str:
+    """Clean C1 control codepoints (U+0080-U+009F) out of a string.
+
+    Three passes:
+    1. UTF-8 trailer: optional 'â' + \\u0080 + another C1 control gets
+       reconstructed by latin-1 encoding then UTF-8 decoding (with an
+       \\xe2 prefix added if 'â' was missing). Recovers smart quotes,
+       en/em dashes, etc. that lost their lead byte.
+    2. Per-codepoint overrides where cp1252 maps wrong (U+008E -> 'é').
+    3. cp1252 default for the rest, except U+0080 and U+0098 which the
+       caller must resolve manually (cp1252 says '€' / '˜' but the corpus
+       uses these for '°' / '÷' / etc.).
+
+    Codepoints undefined in cp1252 (U+0081, U+008D, U+008F, U+0090, U+009D)
+    pass through unchanged.
+    """
+    def utf8_repl(m):
+        s = m.group(0)
+        bs = s.encode("latin-1")
+        if not bs.startswith(b"\xe2"):
+            bs = b"\xe2" + bs
+        try:
+            return bs.decode("utf-8")
+        except UnicodeDecodeError:
+            return s
+    s = _UTF8_TRAILER_RE.sub(utf8_repl, s)
+
+    def repl(m):
+        ch = m.group(0)
+        if ch in _CP1252_OVERRIDES:
+            return _CP1252_OVERRIDES[ch]
+        if ch in _CP1252_SKIP_SINGLE:
+            return ch
+        try:
+            return ch.encode("latin-1").decode("cp1252")
+        except UnicodeDecodeError:
+            return ch
+    return _C1_RE.sub(repl, s)
+
 def split_xdid(xdid):
     """ Split xdid [nyt2015-07-01] into set
     If not matched return None


### PR DESCRIPTION
This came out of the work with xdlint.py-- fixes to common encoding and re-encoding errors for various character encodings. Includes:

- a new document doc/character-encoding.md  that catalogs the various cases seen
- changes to puz2xd.py and puz2xd-standalone.py that encode the various fixes that needed to be done in the existing gxd corpus.
- tests for the weird cases

