### PR TITLE
new rules for detecting and fixing advanced rebuses

### DIFF
--- a/scripts/scan_rebus.py
+++ b/scripts/scan_rebus.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""One-shot scan of gxd corpus to bucket Rebus values by / vs | usage."""
+import os
+import re
+import sys
+
+base = sys.argv[1] if len(sys.argv) > 1 else 'gxd'
+slash_only = []
+pipe_only = []
+both = []
+plain_rebus = 0
+literal_slash = []
+total_files = 0
+files_with_rebus = 0
+
+rebus_re = re.compile(r'^Rebus:\s*(.+)$', re.MULTILINE)
+
+for root, dirs, files in os.walk(base):
+    for fn in files:
+        if not fn.endswith('.xd'):
+            continue
+        total_files += 1
+        fp = os.path.join(root, fn)
+        try:
+            with open(fp, encoding='utf-8') as f:
+                txt = f.read()
+        except Exception:
+            continue
+        m = rebus_re.search(txt)
+        if not m:
+            continue
+        files_with_rebus += 1
+        header_value = m.group(1).strip()
+        parts = [p for p in header_value.split() if '=' in p]
+        has_slash_op = False
+        has_pipe_op = False
+        has_literal_slash = False
+        for p in parts:
+            _, _, v = p.partition('=')
+            if '/' in v:
+                idx = v.index('/')
+                if v[:idx] and v[idx + 1:]:
+                    has_slash_op = True
+                else:
+                    has_literal_slash = True
+            if '|' in v:
+                pieces = v.split('|')
+                if len(pieces) >= 2 and all(pieces):
+                    has_pipe_op = True
+        rel = os.path.relpath(fp, base).replace(os.sep, '/')
+        if has_slash_op and has_pipe_op:
+            both.append(rel)
+        elif has_slash_op:
+            slash_only.append(rel)
+        elif has_pipe_op:
+            pipe_only.append(rel)
+        else:
+            plain_rebus += 1
+        if has_literal_slash:
+            literal_slash.append(rel)
+
+print(f'Total .xd files scanned:     {total_files}')
+print(f'Files with Rebus: header:    {files_with_rebus}')
+print(f'  plain (no / or |):         {plain_rebus}')
+print(f'  uses / operator only:      {len(slash_only)}')
+print(f'  uses | operator only:      {len(pipe_only)}')
+print(f'  uses both / and |:         {len(both)}')
+print(f'  uses literal / (1=/):      {len(literal_slash)}')
+print()
+print('=== files with /  operator only ===')
+for f in slash_only:
+    print(f'  {f}')
+print()
+print('=== files with |  operator only ===')
+for f in pipe_only:
+    print(f'  {f}')
+print()
+print('=== files with BOTH / and | ===')
+for f in both:
+    print(f'  {f}')
+print()
+print('=== files with literal / (1=/) ===')
+for f in literal_slash:
+    print(f'  {f}')

--- a/tests/test_xdlint.py
+++ b/tests/test_xdlint.py
@@ -136,6 +136,19 @@ class TestRebusParsing:
         m = xdlint.parse_rebus_header("1=ONE bare 22=BAD =EMPTY")
         assert set(m) == {"1"}
 
+    def test_parse_rebus_header_tolerates_commas(self):
+        # XD109 flags the comma form, but the parser must still extract
+        # the entries so XD006/XD007 don't degenerate on those files.
+        m = xdlint.parse_rebus_header("1=ONE,2=TWO,3=A/B")
+        assert set(m) == {"1", "2", "3"}
+        assert m["1"].across == ["ONE"]
+        assert m["3"].across == ["A"] and m["3"].down == ["B"]
+
+    def test_parse_rebus_header_mixed_separators(self):
+        # Comma + space combinations also tolerated.
+        m = xdlint.parse_rebus_header("1=ONE, 2=TWO  3=THREE")
+        assert set(m) == {"1", "2", "3"}
+
 
 class TestEnumerateSlots:
     def test_simple_3x3(self):
@@ -197,12 +210,94 @@ class TestAnswerValidation:
         result = self._validate("ONEB", [(0, 0), (0, 1)], ["1B"], rebus, 0)
         assert result is None
 
-    def test_rebus_inline_directional_form(self):
-        # 1=IE/EI; declared answer can embed both inline as "STOOLEI/IE"
+    def test_rebus_directional_quantum_form(self):
+        # 1=IE/EI; an across clue can declare the across reading 'IE'
+        # alone (the "quantum" form — single full spelling using one
+        # direction's alt). The down reading 'EI' is also accepted
+        # because the validator unions across+down at each cell.
         rebus = {"1": xdlint.RebusExpansion(across=["IE"], down=["EI"])}
-        # Single-cell across slot with the declared answer using inline form.
+        assert self._validate("IE", [(0, 0)], ["1"], rebus, 0) is None
+        assert self._validate("EI", [(0, 0)], ["1"], rebus, 0) is None
+
+    def test_rebus_schrodinger_spelled_out_form(self):
+        # Both readings on the clue line, separated by ' / ' (with spaces).
+        rebus = {"1": xdlint.RebusExpansion(across=["IE"], down=["EI"])}
+        assert self._validate("IE / EI", [(0, 0)], ["1"], rebus, 0) is None
+
+    def test_rebus_inline_embed_form_rejected(self):
+        # The deprecated inline-embed form 'IE/EI' (no surrounding spaces
+        # around the slash) is no longer accepted: after consuming 'IE'
+        # at the rebus cell, the trailing '/EI' has no slot to match.
+        rebus = {"1": xdlint.RebusExpansion(across=["IE"], down=["EI"])}
         result = self._validate("IE/EI", [(0, 0)], ["1"], rebus, 0)
-        assert result is None
+        assert result is not None and result[0] == "XD006"
+
+    def test_rebus_multichar_kitkat_style(self):
+        # Real-world example: every rebus cell reads KIT across, KAT down.
+        # Quantum form picks one; spelled-out form lists both.
+        rebus = {"1": xdlint.RebusExpansion(across=["KIT"], down=["KAT"])}
+        assert self._validate("KIT", [(0, 0)], ["1"], rebus, 0) is None
+        assert self._validate("KAT", [(0, 0)], ["1"], rebus, 0) is None
+        assert self._validate("KIT / KAT", [(0, 0)], ["1"], rebus, 0) is None
+
+    def test_rebus_full_schrodinger_answer(self):
+        # CLINTON/BOBDOLE-style: every cell is Schrödinger, but the
+        # alternatives are inter-dependent so only two spellings are
+        # legal. Validator just checks each declared spelling cell-by-cell.
+        rebus = {
+            "C": xdlint.RebusExpansion(across=["C", "P"], down=["C", "P"]),
+            "I": xdlint.RebusExpansion(across=["I", "E"], down=["I", "E"]),
+            "G": xdlint.RebusExpansion(across=["G", "N"], down=["G", "N"]),
+            "A": xdlint.RebusExpansion(across=["A", "I"], down=["A", "I"]),
+            "R": xdlint.RebusExpansion(across=["R", "S"], down=["R", "S"]),
+        }
+        cells = [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4)]
+        grid_row = "CIGAR"  # rebus keys placed in order
+        assert self._validate("CIGAR / PENIS", cells, [grid_row], rebus, 0) is None
+        # Either reading alone is also fine.
+        assert self._validate("CIGAR", cells, [grid_row], rebus, 0) is None
+        assert self._validate("PENIS", cells, [grid_row], rebus, 0) is None
+
+    def test_rebus_quantum_unequal_length_alts(self):
+        # Real-world example: PH/F where every across clue at the rebus
+        # cell reads 'PH' and every down cross reads 'F'. Longest-first
+        # alt matching handles the asymmetry without backtracking.
+        rebus = {"1": xdlint.RebusExpansion(across=["PH"], down=["F"])}
+        # Across slot: G R A {1} → "GRAPH"
+        assert self._validate("GRAPH", [(0, 0), (0, 1), (0, 2), (0, 3)],
+                              ["GRA1"], rebus, 0) is None
+        # Down slot: O {1} → "OF"
+        assert self._validate("OF", [(0, 0), (1, 0)],
+                              ["O", "1"], rebus, 1) is None
+        # Spelled-out Schrödinger form across the same cell.
+        assert self._validate("GRAPH / GRAF",
+                              [(0, 0), (0, 1), (0, 2), (0, 3)],
+                              ["GRA1"], rebus, 0) is None
+
+    def test_rebus_schrodinger_with_asymmetric_down_expansion(self):
+        # Real-world: 1=E|A/EA. Across is Schrödinger over single chars
+        # E or A; down expands the cell to BOTH letters, making the down
+        # cross one cell shorter than its declared answer.
+        # Example: across = STATIONERY / STATIONARY, down = TEARS.
+        rebus = {"1": xdlint.RebusExpansion(across=["E", "A"], down=["EA"])}
+        # Across, spelled-out form (10-cell slot).
+        across_cells = [(0, i) for i in range(10)]
+        across_grid = ["STATION1RY"]
+        assert self._validate("STATIONERY / STATIONARY",
+                              across_cells, across_grid, rebus, 0) is None
+        # Down, single 5-char answer in a 4-cell slot (rebus consumes 2).
+        down_cells = [(0, 0), (1, 0), (2, 0), (3, 0)]
+        down_grid = ["T", "1", "R", "S"]
+        assert self._validate("TEARS", down_cells, down_grid, rebus, 1) is None
+
+    def test_rebus_literal_slash_cell_unaffected(self):
+        # Rebus value '1=/' means the cell content is a literal '/'.
+        # Splitting the declared answer on ' / ' must NOT split on the
+        # bare '/' inside the answer.
+        rebus = {"1": xdlint.RebusExpansion(across=["/"], down=["/"])}
+        # 3-cell across slot: I, /, O — declared "I/O".
+        assert self._validate("I/O", [(0, 0), (0, 1), (0, 2)],
+                              ["I1O"], rebus, 0) is None
 
     def test_rebus_variable_length_alts_match_longest_first(self):
         """Regression test for the alt-by-length sort fix.
@@ -581,6 +676,81 @@ class TestWarningRules:
         f = run_rule("XD108", text)
         assert len(f) == 1
 
+    def test_xd109_comma_separated_rebus_header(self):
+        text = SIMPLE.replace(
+            "Title: T",
+            "Title: T\nRebus: 1=ONE,2=TWO",
+        )
+        f = run_rule("XD109", text)
+        assert any("comma" in x.message.lower() for x in f), f
+
+    def test_xd109_silent_on_canonical_rebus_header(self):
+        text = SIMPLE.replace(
+            "Title: T",
+            "Title: T\nRebus: 1=ONE 2=TWO",
+        )
+        f = run_rule("XD109", text)
+        assert f == []
+
+    def test_xd703_fires_on_inline_embed(self):
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ J/POKER\n"
+        )
+        f = run_rule("XD703", text)
+        assert any("J/POKER" in x.message and "JOKER / POKER" in x.message for x in f), f
+
+    def test_xd703_silent_without_directional_rebus(self):
+        # Same shape but rebus is non-directional — no firing.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=ONE\n\n\n"
+            "ONE12\n\n\n"  # 5-cell slot using 1=ONE plus literals
+            "A1. clue ~ ONEONETWO\n"
+        )
+        f = run_rule("XD703", text)
+        assert f == []
+
+    def test_xd703_silent_on_canonical_spelled_out(self):
+        # Already in canonical form — no firing.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ JOKER / POKER\n"
+        )
+        f = run_rule("XD703", text)
+        assert f == []
+
+    def test_xd703_silent_on_multi_alt_schrodinger(self):
+        # Multi-alt rebus (1=A|B) doesn't trigger the precondition.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=A|B\n\n\n"
+            "1XY\n\n\n"
+            "A1. one reading ~ AXY\n"
+        )
+        f = run_rule("XD703", text)
+        assert f == []
+
+    def test_xd704_fires_on_inline_embed(self):
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ J/POKER\n"
+        )
+        f = run_rule("XD704", text)
+        assert any("J/POKER" in x.message and "JOKER" in x.message for x in f), f
+
+    def test_xd704_silent_on_spelled_out(self):
+        # Already-expanded answer is skipped (collapse should be applied
+        # to original inline-embed only).
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ JOKER / POKER\n"
+        )
+        f = run_rule("XD704", text)
+        assert f == []
+
     def test_xd110_indented_section_header(self):
         text = "  ## Metadata\nTitle: T\n## Grid\nAB\n## Clues\nA1. x ~ AB\n"
         f = run_rule("XD110", text)
@@ -898,6 +1068,175 @@ class TestFixers:
         new, n = xdlint.FIXERS["XD107"][1](text)
         assert n == 1
         assert "First" in new and "Second" not in new
+
+    def test_xd109_comma_to_space_basic(self):
+        text = "Title: T\nRebus: 1=ONE,2=TWO,3=A/B\n\n\nABC\n\n\nA1. x ~ ABC\n"
+        new, n = xdlint.FIXERS["XD109"][1](text)
+        assert n == 1
+        assert "Rebus: 1=ONE 2=TWO 3=A/B\n" in new
+
+    def test_xd109_collapses_comma_with_padding(self):
+        # Comma followed by a space already would naively double the space;
+        # fixer collapses '\s*,\s*' to a single space.
+        text = "Title: T\nRebus: 1=ONE, 2=TWO , 3=A/B\n\n\nABC\n\n\nA1. x ~ ABC\n"
+        new, n = xdlint.FIXERS["XD109"][1](text)
+        assert n == 1
+        assert "Rebus: 1=ONE 2=TWO 3=A/B\n" in new
+
+    def test_xd109_idempotent_on_canonical(self):
+        text = "Title: T\nRebus: 1=ONE 2=TWO\n\n\nABC\n\n\nA1. x ~ ABC\n"
+        new, n = xdlint.FIXERS["XD109"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd703_fixer_expands_inline_embed_across(self):
+        # 'SUPIE/EINEL' → 'SUPIENEL / SUPEINEL' (left=IE, right=EI).
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI\n\n\n"
+            "SUP1NEL\n\n\n"
+            "A1. clue ~ SUPIE/EINEL\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 1
+        assert "A1. clue ~ SUPIENEL / SUPEINEL\n" in new
+
+    def test_xd703_fixer_expands_direction_agnostic(self):
+        # Down slot through the same rebus produces the same expansion.
+        # The expanded form lists both spellings; the human classifies
+        # quantum vs Schrödinger downstream.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI\n\n\n"
+            "S\nU\nP\n1\nN\nE\nL\n\n\n"
+            "D1. clue ~ SUPIE/EINEL\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 1
+        assert "D1. clue ~ SUPIENEL / SUPEINEL\n" in new
+
+    def test_xd703_fixer_expands_two_inline_embeds_in_one_slot(self):
+        # User's VIVIENLEIGH example: two rebus cells, paired left/right.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI 2=EI/IE\n\n\n"
+            "VIV1NL2GH\n\n\n"
+            "A1. actress ~ VIVIE/EINLEI/IEGH\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 1
+        assert "A1. actress ~ VIVIENLEIGH / VIVEINLIEGH\n" in new
+
+    def test_xd703_fixer_expands_short_inline_embed(self):
+        # 'J/POKER' shape: rebus at slot start, short across alt.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. clue ~ J/POKER\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 1
+        assert "A1. clue ~ JOKER / POKER\n" in new
+
+    def test_xd703_fixer_skips_multi_alt_schrodinger(self):
+        # Multi-alt Schrödinger (1=A|B) never has the inline-embed form;
+        # precondition fails and the fixer leaves it alone.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=A|B\n\n\n"
+            "1XY\n\n\n"
+            "A1. one reading ~ AXY\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd703_fixer_idempotent_on_already_expanded(self):
+        # Already in spelled-out form — leave alone.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI\n\n\n"
+            "SUP1NEL\n\n\n"
+            "A1. clue ~ SUPIENEL / SUPEINEL\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd703_fixer_idempotent_on_canonical_single(self):
+        # Already in single canonical form — no inline-embed found, no rewrite.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI\n\n\n"
+            "SUP1NEL\n\n\n"
+            "A1. clue ~ SUPIENEL\n"
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd703_fixer_leaves_genuine_letter_mismatch_alone(self):
+        # Answer doesn't match the grid for non-rebus reasons; walking
+        # fails, fixer leaves the clue untouched.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI\n\n\n"
+            "ABC1DEF\n\n\n"
+            "A1. clue ~ AXCIEDEF\n"  # second char wrong: X instead of B
+        )
+        new, n = xdlint.FIXERS["XD703"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd704_fixer_collapses_across_to_left_half(self):
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ J/POKER\n"
+        )
+        new, n = xdlint.FIXERS["XD704"][1](text)
+        assert n == 1
+        assert "A1. card game ~ JOKER\n" in new
+
+    def test_xd704_fixer_collapses_down_to_right_half(self):
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1\nO\nK\nE\nR\n\n\n"
+            "D1. card game ~ J/POKER\n"
+        )
+        new, n = xdlint.FIXERS["XD704"][1](text)
+        assert n == 1
+        assert "D1. card game ~ POKER\n" in new
+
+    def test_xd704_fixer_handles_multi_rebus_slot(self):
+        # User's VIVIENLEIGH example, collapsed (across keeps left at every cell).
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=IE/EI 2=EI/IE\n\n\n"
+            "VIV1NL2GH\n\n\n"
+            "A1. actress ~ VIVIE/EINLEI/IEGH\n"
+        )
+        new, n = xdlint.FIXERS["XD704"][1](text)
+        assert n == 1
+        assert "A1. actress ~ VIVIENLEIGH\n" in new
+
+    def test_xd704_fixer_skips_already_expanded(self):
+        # Spelled-out form (XD703 already applied) is left alone — the
+        # collapse fix is for the original inline-embed input only.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ JOKER / POKER\n"
+        )
+        new, n = xdlint.FIXERS["XD704"][1](text)
+        assert n == 0
+        assert new == text
+
+    def test_xd703_then_xd704_default_fix_order_expands(self):
+        # When both XD703 and XD704 are in the active set (default --fix
+        # without --enable-only), XD703 runs first and expands. XD704
+        # then sees ' / ' and is a no-op. Verifies the order safety net.
+        text = (
+            "Title: T\nDate: 2024-01-01\nRebus: 1=J/P\n\n\n"
+            "1OKER\n\n\n"
+            "A1. card game ~ J/POKER\n"
+        )
+        new, counts = xdlint.apply_fixes(text, codes=None, unsafe_ok=False)
+        assert "A1. card game ~ JOKER / POKER\n" in new
+        assert counts.get("XD703", 0) >= 1
+        assert counts.get("XD704", 0) == 0  # XD704 saw ' / ' and skipped
 
     def test_xd102_collapse_blank_runs_in_clues(self):
         # Explicit mode so the parser preserves the run inside clues.

--- a/xdlint.py
+++ b/xdlint.py
@@ -475,9 +475,13 @@ def parse_rebus_value(value: str) -> RebusExpansion:
 
 
 def parse_rebus_header(value: str) -> Dict[str, RebusExpansion]:
-    """Parse 'Rebus: 1=ONE 2=TWO 3=A/B' into {key: RebusExpansion}."""
+    """Parse 'Rebus: 1=ONE 2=TWO 3=A/B' into {key: RebusExpansion}.
+
+    Tolerates comma separators ('1=ONE,2=TWO') alongside whitespace so
+    downstream rules don't choke on files that diverge from the spec.
+    XD109 flags the comma form as a style violation."""
     out: Dict[str, RebusExpansion] = {}
-    for part in value.split():
+    for part in re.split(r"[,\s]+", value.strip()):
         if "=" not in part:
             continue
         k, _, v = part.partition("=")
@@ -580,39 +584,57 @@ def _validate_answer_against_slot(
     Returns None on success. Returns (code, message) on failure where
     code is 'XD006' for length problems and 'XD007' for letter problems.
 
-    Handles three answer styles per cell:
-      - Plain (single-letter or rebus, no quantum syntax)
-      - Schrödinger '|' alternates: try each
-      - Inline '<across>/<down>' form: when a rebus has exactly one
-        across-alt and one down-alt and they differ, the declared
-        answer may embed both inline (e.g. STOOLEI/IE for 1=EI/IE).
+    Splits the declared answer on ' / ' (one space, slash, one space)
+    into candidate spellings and validates each against the slot. ALL
+    candidates must validate. This accepts the spelled-out Schrödinger
+    convention — e.g. 'TACK / RACK' for an across slot through a cell
+    whose rebus alts are {T, R}, or 'CIGAR / PENIS' for an all-cells-
+    Schrödinger answer — while rejecting inline-embedded forms like
+    'T/RACK' that paste both readings mid-word (those fail because the
+    bare '/' won't match the next grid cell). The space-flanked split
+    leaves answers with literal '/' content (rebus value '1=/') intact.
 
-    The xd-crossword-tools '|' word-split convention is stripped from
-    the declared answer first (harmless for plain rebus; for Schrödinger
-    answers we don't expect '|' to appear since each clue picks one
-    alternative).
-    """
+    At each rebus cell, accepts any alt from either direction's
+    expansion (union of across and down). Quantum-vs-Schrödinger
+    distinction at the cell level is moot under this framing — the
+    answer-line spelling chooses, not the rebus syntax.
+
+    direction_idx is retained for callsite compatibility but no longer
+    constrains which alts are acceptable.
+
+    The xd-crossword-tools '|' word-split convention is stripped before
+    splitting on ' / '."""
     declared = declared.replace("|", "")
+    candidates = declared.split(" / ")
+    for candidate in candidates:
+        result = _walk_one_answer(candidate, cells, grid, rebus_map)
+        if result is not None:
+            return result
+    return None
+
+
+def _walk_one_answer(
+    declared: str,
+    cells: List[Tuple[int, int]],
+    grid: List[GridRow],
+    rebus_map: Dict[str, RebusExpansion],
+) -> Optional[Tuple[str, str]]:
     di = 0
     for (r, c) in cells:
         ch = grid_get(grid, r, c)
         if ch in rebus_map:
             rebus = rebus_map[ch]
-            chosen = rebus.across if direction_idx == 0 else rebus.down
-            # Try inline '<across>/<down>' first when both directions
-            # have a single distinct expansion.
-            if (len(rebus.across) == 1 and len(rebus.down) == 1
-                    and rebus.across[0] != rebus.down[0]):
-                full = rebus.across[0] + "/" + rebus.down[0]
-                if declared[di:di + len(full)].upper() == full:
-                    di += len(full)
-                    continue
-            # Otherwise match one of the chosen direction's alts. Try the
-            # longer alt first: with unequal-length alts (e.g. 1=A|AB), a
-            # greedy short match would consume the wrong number of cells
-            # and force the next cell into a false XD007.
+            # Union of across+down alts: any reading is acceptable for
+            # any direction, mirroring the spelled-out answer convention.
+            alts = list(rebus.across)
+            for a in rebus.down:
+                if a not in alts:
+                    alts.append(a)
+            # Longest-first: with unequal-length alts (e.g. 1=A|AB or
+            # 1=KIT/KAT alongside 1=KITKAT), a greedy short match would
+            # consume too few characters and misalign the rest of the slot.
             matched = False
-            for alt in sorted(chosen, key=len, reverse=True):
+            for alt in sorted(alts, key=len, reverse=True):
                 if declared[di:di + len(alt)].upper() == alt:
                     di += len(alt)
                     matched = True
@@ -620,8 +642,8 @@ def _validate_answer_against_slot(
             if not matched:
                 if di >= len(declared):
                     return ("XD006", "answer too short for slot")
-                expected = " or ".join(repr(a) for a in chosen)
-                fragment = declared[di:di + max((len(a) for a in chosen), default=1)]
+                expected = " or ".join(repr(a) for a in alts)
+                fragment = declared[di:di + max((len(a) for a in alts), default=1)]
                 return ("XD007", f"at position {di + 1}: expected {expected}, "
                                  f"found {fragment!r}")
         elif ch == WILDCARD_CHAR:
@@ -944,6 +966,79 @@ def _(ctx):
                       f"Date header {hdr_match.group(1)}")
 
 
+@rule("XD703", Severity.WARNING, "deprecated-rebus-inline-embed")
+def _(ctx):
+    """Answer uses the deprecated inline-embed rebus form at a directional
+    rebus cell — '<across>/<down>' pasted mid-word, e.g. 'J/POKER',
+    'ALPH/FA', 'VIVIE/EINLEI/IEGH'. The canonical form spells out both
+    readings: 'JOKER / POKER', 'ALPHA / ALFA'.
+
+    The --fix expands inline-embed to spelled-out (information-preserving;
+    no commitment to quantum vs. Schrödinger). For confirmed-quantum
+    puzzles, a follow-up step collapses spelled-out to the directional
+    half. Only fires on cells with one distinct alt per direction."""
+    rebus_map = _rebus_for(ctx)
+    if not rebus_map:
+        return
+    if not any(len(set(r.across) | set(r.down)) >= 2
+               for r in rebus_map.values()):
+        return  # no multi-alt rebus in this puzzle
+    idx = _slot_index_or_none(ctx)
+    if idx is None:
+        return
+    for clue in ctx.parsed.clues:
+        if clue.direction not in ("A", "D"):
+            continue
+        if clue.pos not in idx:
+            continue
+        _direction, cells = idx[clue.pos]
+        expanded = _expand_inline_embeds(
+            clue.answer, cells, ctx.parsed.grid, rebus_map)
+        if expanded is None:
+            continue
+        yield finding("XD703", Severity.WARNING, clue.line,
+                      f"clue {clue.pos}: deprecated inline-embed rebus "
+                      f"answer {clue.answer!r} (--fix expands to "
+                      f"{expanded!r})")
+
+
+@rule("XD704", Severity.WARNING, "rebus-quantum-collapse-available",
+      experimental=True)
+def _(ctx):
+    """Sibling of XD703: same detection (inline-embed at a directional
+    rebus cell), but the --fix collapses to the directional half (across
+    keeps the left, down keeps the right) instead of expanding.
+
+    Information-discarding — the non-directional half is dropped — so
+    it should only be applied to puzzles classified as quantum. Marked
+    experimental so it doesn't fire alongside XD703 by default; opt in
+    with '--enable-only XD704 --fix' on a per-file basis once you've
+    confirmed the puzzle isn't a Schrödinger."""
+    rebus_map = _rebus_for(ctx)
+    if not rebus_map:
+        return
+    if not any(len(set(r.across) | set(r.down)) >= 2
+               for r in rebus_map.values()):
+        return
+    idx = _slot_index_or_none(ctx)
+    if idx is None:
+        return
+    for clue in ctx.parsed.clues:
+        if clue.direction not in ("A", "D"):
+            continue
+        if clue.pos not in idx:
+            continue
+        _direction, cells = idx[clue.pos]
+        collapsed = _collapse_inline_embeds(
+            clue.answer, cells, ctx.parsed.grid, rebus_map, clue.direction)
+        if collapsed is None:
+            continue
+        yield finding("XD704", Severity.WARNING, clue.line,
+                      f"clue {clue.pos}: rebus inline-embed "
+                      f"{clue.answer!r} collapses to {collapsed!r} "
+                      f"(quantum {clue.direction.lower()}-only reading)")
+
+
 @rule("XD014", Severity.ERROR, "broken-ref")
 def _(ctx):
     """Clue's ^Refs metadata names a position that doesn't exist."""
@@ -1160,6 +1255,21 @@ def _(ctx):
                           f"(first at line {seen[k]})")
         else:
             seen[k] = h.line
+
+
+@rule("XD109", Severity.WARNING, "non-canonical-rebus-separator")
+def _(ctx):
+    """The spec separates Rebus entries with single spaces:
+        Rebus: 1=ONE 2=TWO 3=THREE
+    Files using commas ('1=ONE,2=TWO') parse correctly under the
+    permissive parser, but the comma form is a corpus-wide style
+    violation — flag it so it can be migrated."""
+    for h in ctx.parsed.headers:
+        if h.key.lower() != "rebus":
+            continue
+        if "," in h.value:
+            yield finding("XD109", Severity.WARNING, h.line,
+                          "Rebus header uses comma separators; spec uses spaces")
 
 
 _INDENTED_HEADER_RE = re.compile(r"^[ \t]+##\s+")
@@ -1456,9 +1566,17 @@ FIX_ORDER = [
     "XD107",  # drop duplicate header lines (after XD103: lets XD103 pick the
               # editor-bearing Author even if it isn't the first one, then
               # cleans up the duplicate it leaves behind)
+    "XD109",  # rewrite comma separators in the Rebus header to spaces
     "XD202",  # reorder canonical headers (picks up the new Editor)
     "XD102",  # collapse 2+ blank lines in clues to 1
     "XD013",  # synthesize ^Refs from cross-refs in clue bodies
+    "XD703",  # expand deprecated inline-embed rebus answers ('IE/EI'
+              # mid-word) to the canonical spelled-out form ('IE / EI');
+              # depends on a sane Rebus header so XD109 must run first
+    "XD704",  # alternative collapse to directional alt; experimental and
+              # opt-in via --enable-only XD704. Skips inputs containing
+              # ' / ', so when both XD703 and XD704 are active (default
+              # --fix run) XD703 expands first and XD704 becomes a no-op.
 ]
 
 
@@ -1658,6 +1776,296 @@ def _(text):
     lines = text.splitlines(keepends=True)
     out = [line for i, line in enumerate(lines, 1) if i not in drops]
     return "".join(out), len(drops)
+
+
+def _detect_inline_embed_pair(declared, di, alts):
+    """At position `di` in declared, look for an inline-embed
+    '<X>/<Y>' where X, Y are distinct alts of the current rebus.
+    Returns (left_alt, right_alt, total_consumed) on hit, else None.
+
+    Tries longer pairs first so a 'LW/L|W'-style compound rebus —
+    where the alts are {LW, L, W} — picks the right pair instead
+    of greedily eating a shorter prefix first."""
+    sorted_alts = sorted(alts, key=len, reverse=True)
+    for x in sorted_alts:
+        for y in sorted_alts:
+            if x == y:
+                continue
+            full = x + "/" + y
+            if declared[di:di + len(full)].upper() == full:
+                return (x, y, len(full))
+    return None
+
+
+def _expand_inline_embeds(declared, cells, grid, rebus_map):
+    """Expand the deprecated inline-embed rebus answer form (e.g.
+    'J/POKER', 'ALPH/FA', 'VIVIE/EINLEI/IEGH', 'RACHEL/WEISZ') to the
+    canonical spelled-out form ('JOKER / POKER', 'ALPHA / ALFA', etc.)
+    — two full spellings of the slot with one inline-embed half at
+    every rebus cell going to the left output and the other to the
+    right.
+
+    Information-preserving: produces both spellings instead of
+    committing to a directional collapse. For Schrödinger puzzles this
+    is the canonical form; for quantum puzzles a follow-up pass
+    collapses spelled-out → directional once classified.
+
+    Returns the rewritten string, or None if the answer can't be
+    cleanly walked or contains no inline-embeds. Skips inputs already
+    in spelled-out form (any ' / ' present).
+
+    Inline-embed detection accepts any '<X>/<Y>' pair drawn from a
+    rebus cell's alts (across ∪ down), so straight quantum (1=A/B),
+    bare Schrödinger (1=A|B), and compound forms (1=LW/L|W where the
+    inline-embed halves are the down Schrödinger pair) all match."""
+    if " / " in declared:
+        return None
+
+    left_out = []
+    right_out = []
+    di = 0
+    found_inline = False
+
+    for (r, c) in cells:
+        ch = grid_get(grid, r, c)
+        if ch in rebus_map:
+            rebus = rebus_map[ch]
+            alts = list(rebus.across)
+            for a in rebus.down:
+                if a not in alts:
+                    alts.append(a)
+            inline = _detect_inline_embed_pair(declared, di, alts)
+            if inline is not None:
+                left, right, consumed = inline
+                left_out.append(left)
+                right_out.append(right)
+                di += consumed
+                found_inline = True
+                continue
+            # No inline-embed at this cell — consume a single alt.
+            matched = False
+            for alt in sorted(alts, key=len, reverse=True):
+                if declared[di:di + len(alt)].upper() == alt:
+                    chunk = declared[di:di + len(alt)]
+                    left_out.append(chunk)
+                    right_out.append(chunk)
+                    di += len(alt)
+                    matched = True
+                    break
+            if not matched:
+                return None
+        elif ch == WILDCARD_CHAR:
+            if di >= len(declared):
+                return None
+            left_out.append(declared[di])
+            right_out.append(declared[di])
+            di += 1
+        else:
+            if di >= len(declared):
+                return None
+            if declared[di].upper() != ch.upper():
+                return None
+            left_out.append(declared[di])
+            right_out.append(declared[di])
+            di += 1
+
+    if di < len(declared):
+        return None
+    if not found_inline:
+        return None
+    return "".join(left_out) + " / " + "".join(right_out)
+
+
+def _collapse_inline_embeds(declared, cells, grid, rebus_map, direction):
+    """Collapse inline-embed rebus answers to one half of the inline
+    pair: across keeps the left half of '<X>/<Y>', down keeps the right.
+    Returns rewritten string, or None if the answer can't be cleanly
+    walked or has no inline-embed.
+
+    Skips spelled-out form (' / ' present) — apply this fix to original
+    inline-embed input only, since spelled-out form has already lost the
+    inline-embed structural cue.
+
+    Inline-embed detection mirrors XD703's expand: any '<X>/<Y>' pair
+    drawn from a rebus cell's alts (across ∪ down). Note this means the
+    'left' for compound rebuses (1=LW/L|W) is the matched alt order
+    found by the detector, not necessarily across vs. down."""
+    if " / " in declared:
+        return None
+    direction_idx = 0 if direction == "A" else 1
+    out = []
+    di = 0
+    found_inline = False
+    for (r, c) in cells:
+        ch = grid_get(grid, r, c)
+        if ch in rebus_map:
+            rebus = rebus_map[ch]
+            alts = list(rebus.across)
+            for a in rebus.down:
+                if a not in alts:
+                    alts.append(a)
+            inline = _detect_inline_embed_pair(declared, di, alts)
+            if inline is not None:
+                left, right, consumed = inline
+                out.append(left if direction_idx == 0 else right)
+                di += consumed
+                found_inline = True
+                continue
+            matched = False
+            for alt in sorted(alts, key=len, reverse=True):
+                if declared[di:di + len(alt)].upper() == alt:
+                    out.append(declared[di:di + len(alt)])
+                    di += len(alt)
+                    matched = True
+                    break
+            if not matched:
+                return None
+        elif ch == WILDCARD_CHAR:
+            if di >= len(declared):
+                return None
+            out.append(declared[di])
+            di += 1
+        else:
+            if di >= len(declared):
+                return None
+            if declared[di].upper() != ch.upper():
+                return None
+            out.append(declared[di])
+            di += 1
+    if di < len(declared):
+        return None
+    if not found_inline:
+        return None
+    return "".join(out)
+
+
+@fixer("XD703")
+def _(text):
+    """Expand the deprecated inline-embed rebus answer form to the
+    canonical spelled-out Schrödinger form. 'J/POKER' becomes
+    'JOKER / POKER'; 'VIVIE/EINLEI/IEGH' becomes
+    'VIVIENLEIGH / VIVEINLIEGH'.
+
+    Information-preserving (the down half is kept rather than
+    discarded), reversible, and direction-agnostic. For puzzles that
+    are actually quantum (where only one half is the real answer), a
+    follow-up classification + collapse step picks the directional
+    half. The expansion is a safe first move regardless of which case
+    the puzzle turns out to be.
+
+    Conservative: only acts at cells with one distinct alt per
+    direction — multi-alt Schrödingers (rebus '1=A|B') and unrelated
+    XD007 letter-mismatches are left alone."""
+    parsed = parse(text)
+    if not parsed.grid or not parsed.clues:
+        return text, 0
+    rebus_map = parse_rebus_header(get_header(parsed, "Rebus") or "")
+    if not rebus_map:
+        return text, 0
+
+    slots = enumerate_slots(parsed.grid)
+    idx = {(d, n): cells for (d, n, _r, _c, cells) in slots}
+
+    rewrites = {}
+    for clue in parsed.clues:
+        if clue.direction not in ("A", "D"):
+            continue
+        cells = idx.get((clue.direction, clue.number))
+        if cells is None:
+            continue
+        expanded = _expand_inline_embeds(
+            clue.answer, cells, parsed.grid, rebus_map)
+        if expanded is not None and expanded != clue.answer:
+            rewrites[clue.line] = expanded
+
+    if not rewrites:
+        return text, 0
+
+    lines = text.splitlines(keepends=True)
+    out = []
+    for i, line in enumerate(lines, 1):
+        if i in rewrites:
+            stripped = line.rstrip("\r\n")
+            ending = line[len(stripped):]
+            tilde = stripped.rfind(" ~ ")
+            if tilde < 0:
+                out.append(line)
+                continue
+            out.append(stripped[:tilde + 3] + rewrites[i] + ending)
+        else:
+            out.append(line)
+    return "".join(out), len(rewrites)
+
+
+@fixer("XD704")
+def _(text):
+    """Collapse inline-embed rebus answers to the directional half:
+    'J/POKER' becomes 'JOKER' for across clues, 'POKER' for down.
+    Information-discarding sibling of the XD703 expand fixer — apply
+    only to puzzles confirmed to be quantum (across/down readings
+    differ; not Schrödinger). Conservative: only acts at cells with
+    one distinct alt per direction."""
+    parsed = parse(text)
+    if not parsed.grid or not parsed.clues:
+        return text, 0
+    rebus_map = parse_rebus_header(get_header(parsed, "Rebus") or "")
+    if not rebus_map:
+        return text, 0
+
+    slots = enumerate_slots(parsed.grid)
+    idx = {(d, n): cells for (d, n, _r, _c, cells) in slots}
+
+    rewrites = {}
+    for clue in parsed.clues:
+        if clue.direction not in ("A", "D"):
+            continue
+        cells = idx.get((clue.direction, clue.number))
+        if cells is None:
+            continue
+        collapsed = _collapse_inline_embeds(
+            clue.answer, cells, parsed.grid, rebus_map, clue.direction)
+        if collapsed is not None and collapsed != clue.answer:
+            rewrites[clue.line] = collapsed
+
+    if not rewrites:
+        return text, 0
+
+    lines = text.splitlines(keepends=True)
+    out = []
+    for i, line in enumerate(lines, 1):
+        if i in rewrites:
+            stripped = line.rstrip("\r\n")
+            ending = line[len(stripped):]
+            tilde = stripped.rfind(" ~ ")
+            if tilde < 0:
+                out.append(line)
+                continue
+            out.append(stripped[:tilde + 3] + rewrites[i] + ending)
+        else:
+            out.append(line)
+    return "".join(out), len(rewrites)
+
+
+@fixer("XD109")
+def _(text):
+    """Replace comma separators in the Rebus header with single spaces.
+    Header keys can't contain commas, so a line-wide substitution on the
+    Rebus line is safe."""
+    parsed = parse(text)
+    rebus_lines = {h.line for h in parsed.headers
+                   if h.key.lower() == "rebus" and "," in h.value}
+    if not rebus_lines:
+        return text, 0
+    lines = text.splitlines(keepends=True)
+    out = []
+    for i, line in enumerate(lines, 1):
+        if i in rebus_lines:
+            stripped = line.rstrip("\r\n")
+            ending = line[len(stripped):]
+            out.append(re.sub(r"\s*,\s*", " ", stripped) + ending)
+        else:
+            out.append(line)
+    return "".join(out), len(rebus_lines)
 
 
 # Port of clean_author() from scripts/21-clean-metadata.py. Splits an Author
@@ -1899,16 +2307,28 @@ def apply_fixes(text: str, codes: Optional[set],
 # ---------------------------------------------------------------------------
 
 def iter_xd_paths(roots):
-    """Yield .xd file paths under each root (file or directory)."""
+    """Yield .xd file paths under each root (file or directory).
+
+    Paths are emitted with forward slashes regardless of platform so the
+    finding output is bash/git-bash-friendly on Windows (where os.walk
+    otherwise produces 'gxd/nytimes/2022\\nyt...' with mixed separators
+    that downstream shells can't resolve).
+
+    A nonexistent root prints to stderr and is skipped — silently
+    walking nothing for a typo'd path turned into a 'checked 0 file(s)'
+    surprise too easily."""
     for root in roots:
+        if not os.path.exists(root):
+            print(f"{root}: no such file or directory", file=sys.stderr)
+            continue
         if os.path.isfile(root):
             if root.endswith(".xd"):
-                yield root
+                yield root.replace("\\", "/")
             continue
         for dirpath, _dirnames, filenames in os.walk(root):
             for fn in filenames:
                 if fn.endswith(".xd"):
-                    yield os.path.join(dirpath, fn)
+                    yield os.path.join(dirpath, fn).replace("\\", "/")
 
 
 def _decode_with_findings(data: bytes):
@@ -2161,10 +2581,27 @@ def main():
 
     experimental_codes = {code for (code, _s, _n, exp, _f) in RULES if exp}
 
+    # All codes the runtime knows about: rule codes, parser-level finding
+    # codes, and fixer-only codes. Used to validate --enable-only/--disable
+    # so a typo'd code fails loudly instead of silently selecting nothing.
+    known_codes = (
+        {code for (code, _s, _n, _e, _f) in RULES}
+        | {c for (c, _s, _n) in PARSER_LEVEL_FINDINGS}
+        | set(FIXERS.keys())
+    )
+
     if args.enable_only:
         active = {c.strip() for c in args.enable_only.split(",") if c.strip()}
+        unknown = active - known_codes
+        if unknown:
+            ap.error(f"unknown rule code(s) in --enable-only: "
+                     f"{','.join(sorted(unknown))}")
     elif args.disable:
         disabled = {c.strip() for c in args.disable.split(",") if c.strip()}
+        unknown = disabled - known_codes
+        if unknown:
+            ap.error(f"unknown rule code(s) in --disable: "
+                     f"{','.join(sorted(unknown))}")
         active = {code for (code, _s, _n, _e, _f) in RULES} - disabled
         # Parse-level findings (XD012/XD019/XD021/XD022) are emitted directly
         # by the parser, not via @rule, so they need to be added to `active`


### PR DESCRIPTION
New xdlint rules for advanced rebus quantum/schrodinger cases:

* `XD109`: `non-canonical-rebus-separator` rule + fixer. Flags `Rebus: 1=A,2=B` (comma-separated) and rewrites to space-separated. `parse_rebus_header` made tolerant of commas so downstream rules don't choke on the 166 affected files.
* `XD703`: `deprecated-rebus-inline`-embed rule + fixer. Detects inline-embed answers like `J/POKER`, `ALPH/FA`, `RACHEL/WEISZ` at multi-alt rebus cells. Fix expands to canonical spelled-out form (`JOKER / POKER`, `ALPHA / ALFA`). Information-preserving, if not always correct (see next rule).
* `XD704`: `rebus-quantum-collapse-available` rule + fixer. Same detection as `XD703` but `--fix` collapses to the directional half (across keeps left, down keeps right) for confirmed-quantum puzzles. Information-discarding. (In the example above `ALPHA / ALFA` would be written as `ALPHA`).
* `_validate_answer_against_slot` rewritten -- splits on `/` to accept the spelled-out Schrödinger form (`TACK / RACK`); rejects the inline-embed form (`T/RACK`); accepts union of across+down alts at each rebus cell, so quantum-vs-Schrödinger distinction is now in the answer, not the rebus header.
* `_detect_inline_embed_pair` helper -- finds `<X>/<Y>` patterns in declared answers using any pair from rebus alts. Lets `XD703`/`XD704` work on compound rebuses like `1=LW/L|W` (single multi-char across + Schrödinger down), not just simple quantum.
* CLI improvements: forward-slash path normalization for windows (no more `gxd/nytimes/2022\nyt...`); nonexistent paths print to `stderr` instead of silently walking nothing; `--enable-only` / `--disable` validate rule codes against the registered set and argparse-error on typos.