### PR TITLE
convert2xd: tar input, provisional xdids, overrides, safer overwrite logic

### DIFF
--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -6,6 +6,7 @@
 #   Appends to receipts.tsv
 #
 
+import fnmatch
 import os
 import time
 
@@ -27,6 +28,29 @@ from xdfile import catalog
 
 import xdfile
 
+
+def _load_excludes_file(fpath):
+    out = []
+    with open(fpath) as f:
+        for i, line in enumerate(f):
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            col0 = line.split('\t', 1)[0]
+            if i == 0 and col0 == 'path':
+                continue
+            out.append(col0)
+    return out
+
+
+def _accept_path(path, includes, excludes):
+    if includes and not any(fnmatch.fnmatch(path, pat) for pat in includes):
+        return False
+    if excludes and any(fnmatch.fnmatch(path, pat) for pat in excludes):
+        return False
+    return True
+
+
 def main():
     global args
     parsers = {
@@ -47,8 +71,19 @@ def main():
     p.add_argument('--pubid', default=None, help='PublicationAbbr (pubid) to use')
     p.add_argument('--skip-unchanged', action='store_true', help='Skip writing .xd and appending receipt if output is byte-identical to existing file')
     p.add_argument('--reimport', action='store_true', help='Re-parse and rewrite .xd for sources that have already been received (e.g. to pick up parser or decoder fixes).')
-    p.add_argument('--force', action='store_true', help='With --reimport, overwrite even when a different source owns the xdid.')
+    p.add_argument('--overwrite', action='store_true', help='Overwrite an existing shelf slot owned by a different (ExternalSource, SourceFilename). Without this, sibling-source duplicates and cross-source collisions are skipped with a warning.')
+    p.add_argument('--include', action='append', default=None,
+                   help='Glob (fnmatch) pattern; only SourceFilenames matching at least one --include are processed. May be repeated.')
+    p.add_argument('--exclude', action='append', default=None,
+                   help='Glob (fnmatch) pattern; SourceFilenames matching any --exclude are skipped. May be repeated.')
+    p.add_argument('--excludes-file', action='append', default=None,
+                   help='File of exclude patterns/paths, one per line (or TSV; first column). May be repeated.')
     args = get_args(parser=p)
+
+    includes = list(args.include or [])
+    excludes = list(args.exclude or [])
+    for fpath in args.excludes_file or []:
+        excludes.extend(_load_excludes_file(fpath))
 
     outf = open_output()
 
@@ -84,6 +119,11 @@ def main():
                     continue
 
                 innerfn = strip_toplevel(fn).replace('\\', '/')
+
+                if not _accept_path(innerfn, includes, excludes):
+                    debug("filter excluded: %s" % innerfn)
+                    continue
+
                 if innerfn in source_files:
                     srcrow = source_files[innerfn]
                     CaptureTime = srcrow.DownloadTime
@@ -102,18 +142,21 @@ def main():
                 xdid = ""
                 prev_xdid = ""  # unshelved by default
 
-                existing_xdids = set(r.xdid for r in already_received)
-                if existing_xdids:
-                    if len(existing_xdids) > 1:
-                        warn('previously received this same file under multiple xdids: ' + ' '.join(existing_xdids))
-                    else:
-                        prev_xdid = existing_xdids.pop()
-                        debug('already received as %s' % prev_xdid)
+                # The latest receipt for this (ExternalSource, SourceFilename) is authoritative:
+                # it reflects the most recent xdid (handles shelf-relocations) or '' if the
+                # latest attempt failed to shelve.
+                if already_received:
+                    latest = max(already_received, key=lambda r: r.ReceivedTime)
+                    prev_xdid = latest.xdid
+                    if prev_xdid:
+                        debug('already shelved as %s' % prev_xdid)
 
-                # Default: previously-received sources are skipped entirely (no parse, no write).
-                # --reimport: reprocess and rewrite the .xd.
-                if already_received and not args.reimport:
-                    debug("already received, skipping: %s:%s" % (ExternalSource, SourceFilename))
+                # Default: skip files that have a successful, non-provisional prior shelving.
+                # Files with empty latest xdid (never successfully shelved) and provisional
+                # xdids (shelved into unshelved/) fall through to retry. --reimport reprocesses
+                # everything.
+                if prev_xdid and not catalog.is_provisional(prev_xdid) and not args.reimport:
+                    debug("already shelved as %s, skipping: %s:%s" % (prev_xdid, ExternalSource, SourceFilename))
                     continue
 
                 # try each parser by extension
@@ -150,18 +193,49 @@ def main():
                             xdstr = xd.to_unicode()
 
                             mdtext = "|".join((ExternalSource,InternalSource,SourceFilename))
-                            xdid = prev_xdid or catalog.deduce_xdid(xd, mdtext)
-                            path = catalog.get_shelf_path(xd, args.pubid, mdtext)
-                            if not path:
-                                raise xdfile.NoShelfError("no shelf path for %s" % xd.filename)
 
-                            # --reimport guard: refuse to overwrite if a different source
-                            # owns this xdid (unless --force).
-                            if args.reimport and not args.force and xdid:
+                            # Manual xdid pin from overrides.tsv takes precedence over all
+                            # automatic resolution. Use the pinned xdid for both the receipt
+                            # and the shelf path; pubid is derived from the xdid format.
+                            override_xdid = catalog.lookup_xdid_override(ExternalSource, SourceFilename)
+                            if override_xdid:
+                                xdid = override_xdid
+                                path = catalog.shelf_path_from_xdid(override_xdid)
+                                if not path:
+                                    raise xdfile.NoShelfError("override xdid %s is not a recognized shelf format" % override_xdid)
+                            else:
+                                # Resolve pubid once and pass it down — keeps deduce_xdid and
+                                # get_shelf_path consistent and avoids triple-resolution per file.
+                                pubid = args.pubid or catalog.resolve_pubid(xd, mdtext)
+
+                                # Strict deduction for the relocation comparison: ignore the
+                                # provisional fallback, only flag real-vs-real divergences.
+                                deduced_xdid_strict = catalog.deduce_xdid(xd, pubid, mdtext, strict=True)
+                                if (args.reimport and prev_xdid and not catalog.is_provisional(prev_xdid)
+                                        and deduced_xdid_strict and prev_xdid != deduced_xdid_strict):
+                                    warn("shelf relocation: %s previously %s, current headers deduce %s" % (
+                                        SourceFilename, prev_xdid, deduced_xdid_strict))
+                                # Reuse prev_xdid only when it's a real (non-provisional) shelving;
+                                # for provisional or empty prev_xdid, deduce fresh (may now succeed).
+                                if prev_xdid and not catalog.is_provisional(prev_xdid):
+                                    xdid = prev_xdid
+                                else:
+                                    xdid = catalog.deduce_xdid(xd, pubid, mdtext)
+                                path = catalog.get_shelf_path(xd, pubid, mdtext)
+                                if not path:
+                                    raise xdfile.NoShelfError("no shelf path for %s" % xd.filename)
+
+                            # Always-on ownership guard: refuse to overwrite if a different
+                            # (ExternalSource, SourceFilename) already owns this xdid. This
+                            # catches both cross-source overwrites and same-source sibling
+                            # duplicates (same logical puzzle filed under multiple paths in
+                            # the archive). Provisional xdids are hash-unique by construction
+                            # and don't need this guard. --overwrite overrides.
+                            if not args.overwrite and xdid and not catalog.is_provisional(xdid):
                                 latest = metadb.latest_receipt_for_xdid(xdid)
-                                if latest and latest.ExternalSource != ExternalSource:
-                                    warn("xdid %s last imported from '%s', not overwriting from '%s' (use --force to override)" % (
-                                        xdid, latest.ExternalSource, ExternalSource))
+                                if latest and (latest.ExternalSource, latest.SourceFilename) != (ExternalSource, SourceFilename):
+                                    warn("xdid %s already owned by (%s, %s); not overwriting from (%s, %s) (use --overwrite to override)" % (
+                                        xdid, latest.ExternalSource, latest.SourceFilename, ExternalSource, SourceFilename))
                                     owned_by_other = True
                                     rejected = ""
                                     break
@@ -200,6 +274,22 @@ def main():
                             else:
                                 outf.write_file(path + ".xd", xdstr, dt)
 
+                            # Promotion cleanup: a previously-provisional shelving
+                            # has been replaced by a real (or different provisional)
+                            # one. Remove the old provisional .xd so receipts and
+                            # disk stay in sync.
+                            if (catalog.is_provisional(prev_xdid)
+                                    and prev_xdid != xdid
+                                    and not unchanged):
+                                try:
+                                    old_relpath = catalog.provisional_path(prev_xdid, ExternalSource) + ".xd"
+                                    full_old = os.path.join(outf.toplevel, old_relpath)
+                                    if os.path.exists(full_old):
+                                        os.unlink(full_old)
+                                        debug("promoted: removed old provisional %s" % old_relpath)
+                                except AttributeError:
+                                    pass
+
                             rejected = ""
                             break  # stop after first successful parsing
                         except xdfile.NoShelfError as e:
@@ -213,16 +303,21 @@ def main():
                     if rejected:
                         error("could not convert: %s" % rejected)
 
-                    # Receipt policy: append only when this is a newly-received source
-                    # that produced a written .xd. Rewrites of already-received sources
-                    # don't add a new receipt (the prior one already binds SourceFilename
-                    # → xdid). Unchanged writes and ownership-blocked writes skip too.
-                    if already_received:
-                        debug("already received %s:%s" % (ExternalSource, SourceFilename))
+                    # Receipt policy: append when the xdid we just assigned is non-empty AND
+                    # represents a state change from the latest prior receipt. This covers:
+                    #   - brand-new sources (no prior receipt)
+                    #   - retries that succeeded (prior xdid empty, new xdid assigned)
+                    #   - provisional-to-real promotions (prior xdid was provisional, new is real)
+                    # Skips when: parse failed (empty xdid), the xdid is unchanged from latest
+                    # (no new info), the slot is owned by another key, or write was a no-op.
+                    if not xdid:
+                        debug("no xdid (parse failed), receipt skip %s:%s" % (ExternalSource, SourceFilename))
                     elif owned_by_other:
                         debug("slot owned, receipt skip %s:%s" % (ExternalSource, SourceFilename))
                     elif unchanged:
                         debug("unchanged receipt skip %s:%s" % (ExternalSource, SourceFilename))
+                    elif already_received and prev_xdid == xdid:
+                        debug("xdid unchanged from latest receipt, skip %s:%s" % (ExternalSource, SourceFilename))
                     else:
                         receipts.append([
                             CaptureTime,

--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -215,15 +215,34 @@ def main():
                                         and deduced_xdid_strict and prev_xdid != deduced_xdid_strict):
                                     warn("shelf relocation: %s previously %s, current headers deduce %s" % (
                                         SourceFilename, prev_xdid, deduced_xdid_strict))
-                                # Reuse prev_xdid only when it's a real (non-provisional) shelving;
-                                # for provisional or empty prev_xdid, deduce fresh (may now succeed).
-                                if prev_xdid and not catalog.is_provisional(prev_xdid):
+                                # Reuse prev_xdid only when it's a real (non-provisional) shelving
+                                # AND current headers still support a real xdid. The latter check
+                                # catches "regressions" where prev_xdid was set under different
+                                # rules (e.g. a stricter pubregex was relaxed, or a Number heuristic
+                                # was tightened) and keeping it would put xdid and path out of sync.
+                                is_regression = (prev_xdid and not catalog.is_provisional(prev_xdid)
+                                                 and not deduced_xdid_strict)
+                                if prev_xdid and not catalog.is_provisional(prev_xdid) and deduced_xdid_strict:
                                     xdid = prev_xdid
                                 else:
                                     xdid = catalog.deduce_xdid(xd, pubid, mdtext)
                                 path = catalog.get_shelf_path(xd, pubid, mdtext)
                                 if not path:
                                     raise xdfile.NoShelfError("no shelf path for %s" % xd.filename)
+
+                                # Single warning per provisional shelving with whichever reason
+                                # applies. Suppresses the duplicated/unclear messages that used
+                                # to come from get_shelf_path AND the convert loop separately.
+                                if catalog.is_provisional(xdid):
+                                    if is_regression:
+                                        warn("%s: unshelved as %s (was %s)" % (
+                                            SourceFilename, xdid, prev_xdid))
+                                    elif xdid.startswith(catalog.PROVISIONAL_MARKER):
+                                        warn("%s: unshelved as %s (no pubid resolved)" % (
+                                            SourceFilename, xdid))
+                                    else:
+                                        warn("%s: unshelved as %s (no Date or Number)" % (
+                                            SourceFilename, xdid))
 
                             # Always-on ownership guard: refuse to overwrite if a different
                             # (ExternalSource, SourceFilename) already owns this xdid. This

--- a/scripts/18-convert2xd.py
+++ b/scripts/18-convert2xd.py
@@ -69,9 +69,25 @@ def main():
     p.add_argument('--extsrc', default=None, help='Value for receipts.ExternalSource')
     p.add_argument('--intsrc', default=None, help='Value for receipts.InternalSource')
     p.add_argument('--pubid', default=None, help='PublicationAbbr (pubid) to use')
-    p.add_argument('--skip-unchanged', action='store_true', help='Skip writing .xd and appending receipt if output is byte-identical to existing file')
+    p.add_argument('--skip-unchanged', action='store_true', help='Skip writing .xd if output is byte-identical to the existing file. Receipt rows are still appended (use receipts.tsv as the source of truth for which SourceFilenames map to which xdid).')
     p.add_argument('--reimport', action='store_true', help='Re-parse and rewrite .xd for sources that have already been received (e.g. to pick up parser or decoder fixes).')
-    p.add_argument('--overwrite', action='store_true', help='Overwrite an existing shelf slot owned by a different (ExternalSource, SourceFilename). Without this, sibling-source duplicates and cross-source collisions are skipped with a warning.')
+    p.add_argument('--conflict-mode', choices=['skip', 'rename', 'replace', 'overwrite'], default='skip',
+                   help='How to handle a SourceFilename whose canonical xdid is already claimed by '
+                        'a different SourceFilename (per receipts.tsv) AND whose converted .xd '
+                        'differs from the canonical slot. '
+                        '"skip" (default): warn and drop the loser. '
+                        '"rename": mint a stable variant xdid (e.g. nys2007-03-27a) and shelve '
+                        'the loser there. '
+                        '"replace": newcomer becomes canonical; the prior claimant is demoted '
+                        'to a variant (their content is moved to the variant path and a demotion '
+                        'receipt is appended). '
+                        '"overwrite": newcomer becomes canonical and writes over the prior content; '
+                        'both source files end up mapped to the same xdid in receipts (history '
+                        'preserved, but the prior content is lost from disk). '
+                        'Equal-bytes "collisions" are never treated as conflicts in any mode: the '
+                        'loser silently records a provenance receipt for the canonical xdid. '
+                        'Caveat: with --include/--exclude filters, an unprocessed sibling can '
+                        'silently go stale relative to a reimported canonical slot — no detection.')
     p.add_argument('--include', action='append', default=None,
                    help='Glob (fnmatch) pattern; only SourceFilenames matching at least one --include are processed. May be repeated.')
     p.add_argument('--exclude', action='append', default=None,
@@ -88,8 +104,11 @@ def main():
     outf = open_output()
 
     # Track shelf paths written during this run, keyed by path -> (ExternalSource, SourceFilename),
-    # to prevent a second source file in the same run from silently overwriting the first.
+    # to identify the within-run canonical claimant when receipts have no prior claim.
     paths_written_this_run = {}
+    # Variant xdids minted during this run, so a second collision in the same run
+    # doesn't try to mint the same letter as the first.
+    variants_minted_this_run = set()
 
     for input_source in args.inputs:
         try:
@@ -244,36 +263,142 @@ def main():
                                         warn("%s: unshelved as %s (no Date or Number)" % (
                                             SourceFilename, xdid))
 
-                            # Always-on ownership guard: refuse to overwrite if a different
-                            # (ExternalSource, SourceFilename) already owns this xdid. This
-                            # catches both cross-source overwrites and same-source sibling
-                            # duplicates (same logical puzzle filed under multiple paths in
-                            # the archive). Provisional xdids are hash-unique by construction
-                            # and don't need this guard. --overwrite overrides.
-                            if not args.overwrite and xdid and not catalog.is_provisional(xdid):
-                                latest = metadb.latest_receipt_for_xdid(xdid)
-                                if latest and (latest.ExternalSource, latest.SourceFilename) != (ExternalSource, SourceFilename):
-                                    warn("xdid %s already owned by (%s, %s); not overwriting from (%s, %s) (use --overwrite to override)" % (
-                                        xdid, latest.ExternalSource, latest.SourceFilename, ExternalSource, SourceFilename))
+                            # Canonical-claimant resolution. Latest-receipt-per-xdid is the
+                            # current claimant: receipts are append-only and every state
+                            # change writes a new row, so the most-recent receipt mapping
+                            # a SourceFilename to xdid is the live canonical claim. When
+                            # no prior receipt exists for xdid, the first writer this run
+                            # becomes canonical. Provisional xdids are hash-unique by
+                            # construction and skip this entire decision.
+                            own_key = (ExternalSource, SourceFilename)
+                            am_canonical = True
+                            canonical_owner_label = None
+                            if xdid and not catalog.is_provisional(xdid):
+                                run_owner = paths_written_this_run.get(path)
+                                if run_owner and run_owner != own_key:
+                                    am_canonical = False
+                                    canonical_owner_label = run_owner
+                                else:
+                                    latest = metadb.latest_receipt_for_xdid(xdid)
+                                    if (latest
+                                            and (latest.ExternalSource, latest.SourceFilename) != own_key):
+                                        am_canonical = False
+                                        canonical_owner_label = (latest.ExternalSource, latest.SourceFilename)
+
+                            is_equal_provenance = False
+                            if not am_canonical:
+                                # Compare loser's converted bytes to the canonical-slot bytes.
+                                # Equal -> silent provenance receipt; different -> dispatch
+                                # on --conflict-mode.
+                                full_canonical = os.path.join(outf.toplevel, path + ".xd")
+                                try:
+                                    with open(full_canonical, 'rb') as f:
+                                        canonical_bytes = f.read()
+                                except (FileNotFoundError, OSError):
+                                    canonical_bytes = None
+                                new_bytes = xdstr.encode('utf-8')
+
+                                if canonical_bytes == new_bytes:
+                                    is_equal_provenance = True
+                                    debug("equal-bytes provenance for %s from (%s, %s); claimed by (%s, %s)" % (
+                                        xdid, ExternalSource, SourceFilename,
+                                        canonical_owner_label[0], canonical_owner_label[1]))
+                                elif args.conflict_mode == 'rename':
+                                    variant = catalog.mint_variant_xdid(
+                                        xdid, ExternalSource, SourceFilename,
+                                        in_run_claimed=variants_minted_this_run)
+                                    if not variant:
+                                        warn("xdid %s claimed by (%s, %s); could not mint variant for (%s, %s) (all letter slots used)" % (
+                                            xdid, canonical_owner_label[0], canonical_owner_label[1],
+                                            ExternalSource, SourceFilename))
+                                        owned_by_other = True
+                                        rejected = ""
+                                        break
+                                    warn("xdid %s claimed by (%s, %s); forking (%s, %s) to variant %s" % (
+                                        xdid, canonical_owner_label[0], canonical_owner_label[1],
+                                        ExternalSource, SourceFilename, variant))
+                                    xdid = variant
+                                    path = catalog.shelf_path_from_xdid(variant)
+                                    if not path:
+                                        raise xdfile.NoShelfError("variant xdid %s has no shelf path" % variant)
+                                    variants_minted_this_run.add(variant)
+                                    am_canonical = True
+                                    canonical_owner_label = None
+                                elif args.conflict_mode == 'replace':
+                                    # Demote the prior canonical claimant to a variant: write
+                                    # their disk bytes to a freshly-minted variant path and
+                                    # append a demotion receipt for them. Newcomer then takes
+                                    # the canonical write path normally.
+                                    old_extsrc, old_sourcefilename = canonical_owner_label
+                                    variant = catalog.mint_variant_xdid(
+                                        xdid, old_extsrc, old_sourcefilename,
+                                        in_run_claimed=variants_minted_this_run)
+                                    if not variant:
+                                        warn("xdid %s claimed by (%s, %s); cannot displace (no variant slots left); dropping (%s, %s)" % (
+                                            xdid, old_extsrc, old_sourcefilename,
+                                            ExternalSource, SourceFilename))
+                                        owned_by_other = True
+                                        rejected = ""
+                                        break
+                                    variant_path = catalog.shelf_path_from_xdid(variant)
+                                    if not variant_path:
+                                        raise xdfile.NoShelfError("variant xdid %s has no shelf path" % variant)
+                                    warn("xdid %s claimed by (%s, %s); demoting them to %s, (%s, %s) becomes canonical" % (
+                                        xdid, old_extsrc, old_sourcefilename, variant,
+                                        ExternalSource, SourceFilename))
+                                    if canonical_bytes is not None:
+                                        outf.write_file(variant_path + ".xd",
+                                                        canonical_bytes.decode('utf-8'), dt)
+                                    else:
+                                        warn("canonical .xd missing on disk for %s; demotion receipt only, %s.xd will materialize on next reimport of (%s, %s)" % (
+                                            xdid, variant_path, old_extsrc, old_sourcefilename))
+                                    # Carry over CaptureTime/InternalSource from the demotee's
+                                    # latest prior receipt — the demotion is about state, not
+                                    # about reingesting the upstream file.
+                                    old_prior = metadb.check_already_received(old_extsrc, old_sourcefilename)
+                                    if old_prior:
+                                        prior_latest = max(old_prior, key=lambda r: r.ReceivedTime)
+                                        old_capture = prior_latest.CaptureTime
+                                        old_internal = prior_latest.InternalSource
+                                    else:
+                                        old_capture = ""
+                                        old_internal = ""
+                                    receipts.append([
+                                        old_capture,
+                                        ReceivedTime,
+                                        old_extsrc,
+                                        old_internal,
+                                        old_sourcefilename,
+                                        variant,
+                                    ])
+                                    variants_minted_this_run.add(variant)
+                                    paths_written_this_run[variant_path] = (old_extsrc, old_sourcefilename)
+                                    am_canonical = True
+                                    canonical_owner_label = None
+                                elif args.conflict_mode == 'overwrite':
+                                    # Newcomer's bytes replace the canonical-slot bytes.
+                                    # Both source files remain mapped to xdid in receipts;
+                                    # the prior claimant's disk content is lost (their
+                                    # original receipt still records the historical claim).
+                                    warn("xdid %s claimed by (%s, %s); overwriting canonical content with bytes from (%s, %s) (prior content lost)" % (
+                                        xdid, canonical_owner_label[0], canonical_owner_label[1],
+                                        ExternalSource, SourceFilename))
+                                    am_canonical = True
+                                    canonical_owner_label = None
+                                else:
+                                    # conflict_mode == 'skip' (default): warn and drop the loser.
+                                    warn("xdid %s claimed by (%s, %s); not writing (%s, %s) (use --conflict-mode=rename/replace/overwrite to keep the new content)" % (
+                                        xdid, canonical_owner_label[0], canonical_owner_label[1],
+                                        ExternalSource, SourceFilename))
                                     owned_by_other = True
                                     rejected = ""
                                     break
 
-                            # Within-run collision guard: if another source in this run already
-                            # wrote this shelf path, skip rather than silently overwrite. Sort
-                            # order makes this deterministic — the earliest-processed file
-                            # (most recent mtime, filename desc on tie) keeps the slot.
-                            own_key = (ExternalSource, SourceFilename)
-                            run_owner = paths_written_this_run.get(path)
-                            if run_owner and run_owner != own_key:
-                                warn("shelf slot %s already written this run by %s; not overwriting with %s" % (
-                                    path + ".xd", run_owner[1], SourceFilename))
-                                owned_by_other = True
-                                rejected = ""
-                                break
-
-                            unchanged = False
-                            if args.skip_unchanged:
+                            # Bytes-equal optimization. --skip-unchanged checks the canonical
+                            # write path. is_equal_provenance is always a no-op write (we know
+                            # bytes match by definition).
+                            unchanged = is_equal_provenance
+                            if args.skip_unchanged and not is_equal_provenance:
                                 try:
                                     full = os.path.join(outf.toplevel, path + ".xd")
                                     if os.path.exists(full):
@@ -284,9 +409,12 @@ def main():
                                 except AttributeError:
                                     pass
 
-                            # Claim the slot regardless of whether we actually write, so a later
-                            # source in the same run can't sneak in behind a --skip-unchanged no-op.
-                            paths_written_this_run[path] = own_key
+                            # Claim the slot for canonical writers (and freshly-renamed
+                            # variants, which start their own claim). Equal-bytes provenance
+                            # writers don't displace the canonical claim — they just record
+                            # an additional receipt.
+                            if not is_equal_provenance:
+                                paths_written_this_run[path] = own_key
 
                             if unchanged:
                                 debug("unchanged, skipping: %s" % (path + ".xd"))
@@ -327,14 +455,15 @@ def main():
                     #   - brand-new sources (no prior receipt)
                     #   - retries that succeeded (prior xdid empty, new xdid assigned)
                     #   - provisional-to-real promotions (prior xdid was provisional, new is real)
-                    # Skips when: parse failed (empty xdid), the xdid is unchanged from latest
-                    # (no new info), the slot is owned by another key, or write was a no-op.
+                    #   - new provenance: this SourceFilename now also resolves to xdid that a
+                    #     different SourceFilename had already claimed (byte-identical conversion)
+                    # Skips when: parse failed (empty xdid), the slot was claimed by a divergent
+                    # SourceFilename and we dropped (skip mode), or the latest receipt for this
+                    # SourceFilename already maps to this same xdid (no new info).
                     if not xdid:
                         debug("no xdid (parse failed), receipt skip %s:%s" % (ExternalSource, SourceFilename))
                     elif owned_by_other:
-                        debug("slot owned, receipt skip %s:%s" % (ExternalSource, SourceFilename))
-                    elif unchanged:
-                        debug("unchanged receipt skip %s:%s" % (ExternalSource, SourceFilename))
+                        debug("slot claimed by another, receipt skip %s:%s" % (ExternalSource, SourceFilename))
                     elif already_received and prev_xdid == xdid:
                         debug("xdid unchanged from latest receipt, skip %s:%s" % (ExternalSource, SourceFilename))
                     else:

--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -197,8 +197,11 @@ def deduce_set_seqnum(xd):
     if dt:
         xd.set_header("Date", dt)
     else:
-        # check for number in full path (eltana dir had number)
-        m = re.search(r'(\d+)', xd.filename)
+        # Number is the trailing digit run of the basename, optionally followed
+        # by a single letter variant marker (e.g. "bg-002a"). Embedded digits
+        # like year fragments ("wp92bms") or directory indices aren't sequence
+        # numbers and shouldn't be guessed at.
+        m = re.search(r'(\d+)[a-zA-Z]?$', base)
         if m:
             xd.set_header("Number", int(m.group(1)))
 
@@ -251,7 +254,6 @@ def get_shelf_path(xd, pubid, mdtext, strict=False):
             return None
         extsrc, _, _ = _parse_mdtext(mdtext)
         xdid = _provisional_xdid(mdtext)
-        utils.warn("could not resolve pubid for '%s'; assigning provisional xdid %s" % (xd.filename, xdid))
         return "unshelved/%s/%s" % (extsrc or "unknown", xdid)
 
     publisher = publ.PublisherAbbr
@@ -268,6 +270,5 @@ def get_shelf_path(xd, pubid, mdtext, strict=False):
     if strict:
         return None
     xdid = _provisional_xdid(mdtext, pubid=pubid)
-    utils.warn("neither Number nor Date for '%s'; assigning provisional xdid %s" % (xd.filename, xdid))
     return "%s/unshelved/%s" % (publisher or pubid, xdid)
 

--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -1,4 +1,5 @@
 
+import hashlib
 import re
 
 from xdfile import utils
@@ -6,6 +7,55 @@ from xdfile import metadatabase as metadb
 import xdfile
 
 PUBREGEX_TSV = 'gxd/pubregex.tsv'
+OVERRIDES_TSV = 'gxd/overrides.tsv'
+
+# Provisional xdids carry the literal "unshelved-" substring as their discriminator.
+# Two shapes:
+#   no pubid resolved:        unshelved-<hash8>-<slug>
+#   pubid resolved, no date:  <pubid>-unshelved-<hash8>-<slug>
+PROVISIONAL_MARKER = "unshelved-"
+_SLUG_RE = re.compile(r'[^a-z0-9-]')
+
+
+def is_provisional(xdid):
+    return bool(xdid) and PROVISIONAL_MARKER in xdid
+
+
+def _parse_mdtext(mdtext):
+    """mdtext is "|".join((ExternalSource, InternalSource, SourceFilename))."""
+    parts = (mdtext or "").split("|", 2)
+    while len(parts) < 3:
+        parts.append("")
+    return tuple(parts)
+
+
+def _provisional_hash(extsrc, source_filename):
+    return hashlib.sha1(("%s|%s" % (extsrc, source_filename)).encode("utf-8")).hexdigest()[:8]
+
+
+def _provisional_slug(source_filename, max_len=20):
+    base = utils.parse_pathname(source_filename).base.lower()
+    cleaned = _SLUG_RE.sub('', base)
+    return cleaned[:max_len] or 'x'
+
+
+def _provisional_xdid(mdtext, pubid=None):
+    extsrc, _, source_filename = _parse_mdtext(mdtext)
+    h = _provisional_hash(extsrc, source_filename)
+    slug = _provisional_slug(source_filename)
+    if pubid:
+        return "%s-%s%s-%s" % (pubid, PROVISIONAL_MARKER, h, slug)
+    return "%s%s-%s" % (PROVISIONAL_MARKER, h, slug)
+
+
+def provisional_path(xdid, extsrc):
+    """Disk path (without .xd extension) for a provisional xdid."""
+    if xdid.startswith(PROVISIONAL_MARKER):
+        return "unshelved/%s/%s" % (extsrc or "unknown", xdid)
+    pubid = xdid.split("-" + PROVISIONAL_MARKER, 1)[0]
+    publ = metadb.xd_publications().get(pubid)
+    publisher = publ.PublisherAbbr if publ else pubid
+    return "%s/unshelved/%s" % (publisher, xdid)
 
 
 def get_publication(xd):
@@ -41,7 +91,8 @@ def get_publication(xd):
     elif len(matching_pubs) == 1:
         return matching_pubs.pop()[1]
 
-    return sorted(matching_pubs)[0][1]
+    # Stable sort by (priority, PublicationAbbr); AttrDict isn't directly orderable.
+    return sorted(matching_pubs, key=lambda x: (x[0], x[1].PublicationAbbr))[0][1]
 
 # some regex heuristics for shelving
 _pubregex_cache = None
@@ -55,6 +106,50 @@ def _load_pubregex():
             utils.error("File not exists: %s" % PUBREGEX_TSV, severity='WARNING')
             _pubregex_cache = []
     return _pubregex_cache
+
+
+# Per-source manual xdid pins. Format: ExternalSource, SourceFilename, xdid, note
+_overrides_cache = None
+
+
+def _load_overrides():
+    global _overrides_cache
+    if _overrides_cache is None:
+        _overrides_cache = {}
+        try:
+            rows = list(utils.parse_tsv_data(open(OVERRIDES_TSV, 'r').read(), "Override"))
+            for r in rows:
+                if r.xdid:
+                    _overrides_cache[(r.ExternalSource, r.SourceFilename)] = r.xdid
+        except FileNotFoundError:
+            pass
+    return _overrides_cache
+
+
+def lookup_xdid_override(extsrc, source_filename):
+    """Return the manually-pinned xdid for this (ExternalSource, SourceFilename), or None."""
+    return _load_overrides().get((extsrc, source_filename))
+
+
+def shelf_path_from_xdid(xdid):
+    """Derive shelf path (without .xd extension) from a real xdid string.
+    Returns None if the xdid format isn't recognized."""
+    # Date format: <pubid>YYYY-MM-DD
+    m = re.match(r'^([a-z]+)\d{4}-\d{2}-\d{2}$', xdid)
+    if m:
+        pubid = m.group(1)
+        publ = metadb.xd_publications().get(pubid)
+        publisher = publ.PublisherAbbr if publ else pubid
+        year = xdid[len(pubid):len(pubid) + 4]
+        return "%s/%s/%s" % (publisher, year, xdid)
+    # Number format: <pubid>-NNN
+    m = re.match(r'^([a-z]+)-\d+$', xdid)
+    if m:
+        pubid = m.group(1)
+        publ = metadb.xd_publications().get(pubid)
+        publisher = publ.PublisherAbbr if publ else pubid
+        return "%s/%s" % (publisher, xdid)
+    return None
 
 
 def find_pubid(rowstr):
@@ -88,7 +183,6 @@ def find_pubid(rowstr):
         utils.warn("%s: too many implicit pubid matches (%s)" % (rowstr, " ".join(implicit)))
         return None
 
-    utils.warn("%s: no pubid match" % rowstr)
     return None
 
 
@@ -109,15 +203,28 @@ def deduce_set_seqnum(xd):
             xd.set_header("Number", int(m.group(1)))
 
 
-def deduce_xdid(xd, mdtext):
-
+def resolve_pubid(xd, mdtext):
+    """Best-effort pubid resolution: filename/metadata regex first, falling back
+    to Copyright-header lookup via get_publication. Returns None if neither stage
+    resolves a pubid."""
     pubid = find_pubid(mdtext)
+    if pubid:
+        return pubid
+    utils.info("%s: filename did not match any known publisher, checking file headers" % mdtext)
+    publ = get_publication(xd)
+    if publ:
+        return publ.PublicationAbbr
+    return None
+
+
+def deduce_xdid(xd, pubid, mdtext, strict=False):
+    """Return an xdid for xd. Caller is responsible for resolving pubid (e.g. via
+    resolve_pubid()). pubid may be None — strict=True returns None in that case;
+    strict=False returns a provisional xdid."""
     if not pubid:
-        publication = get_publication(xd)
-        if publication:
-            pubid = publication.PublicationAbbr
-        else:
+        if strict:
             return None
+        return _provisional_xdid(mdtext)
 
     num = xd.get_header('Number')
     if num:
@@ -125,27 +232,27 @@ def deduce_xdid(xd, mdtext):
 
     dt = xd.get_header("Date")
     if dt:
-        # year = xdfile.year_from_date(dt)
         return "%s%s" % (pubid, dt)
 
-
-def get_shelf_path(xd, pubid, mdtext):
-    publisher = ""
-    if not pubid:
-        pubid = find_pubid(mdtext)
-
-    if pubid:
-        publ = metadb.xd_publications()[pubid]
-    else:
-        publ = get_publication(xd)
-        if publ:
-            pubid = publ.PublicationAbbr
-        else:
-            return None
-
-    if not pubid:
-        utils.warn("unknown pubid for '%s'" % xd.filename)
+    if strict:
         return None
+    return _provisional_xdid(mdtext, pubid=pubid)
+
+
+def get_shelf_path(xd, pubid, mdtext, strict=False):
+    """Return shelf path (without .xd extension). Caller is responsible for
+    resolving pubid. With strict=False (default), falls through to a provisional
+    path under unshelved/* when pubid or Date/Number is missing; strict=True
+    returns None in those cases."""
+    publ = metadb.xd_publications().get(pubid) if pubid else None
+
+    if not publ:
+        if strict:
+            return None
+        extsrc, _, _ = _parse_mdtext(mdtext)
+        xdid = _provisional_xdid(mdtext)
+        utils.warn("could not resolve pubid for '%s'; assigning provisional xdid %s" % (xd.filename, xdid))
+        return "unshelved/%s/%s" % (extsrc or "unknown", xdid)
 
     publisher = publ.PublisherAbbr
 
@@ -154,10 +261,13 @@ def get_shelf_path(xd, pubid, mdtext):
         return "%s/%s-%03d" % (publisher or pubid, pubid, int(num))
 
     dt = xd.get_header("Date")
-    if not dt:
-        utils.warn("neither Number nor Date for '%s'" % xd.filename)
-        return 'misc/' + xd.filename
+    if dt:
+        year = xdfile.year_from_date(dt)
+        return "%s/%s/%s%s" % (publisher, year, pubid, dt)
 
-    year = xdfile.year_from_date(dt)
-    return "%s/%s/%s%s" % (publisher, year, pubid, dt)
+    if strict:
+        return None
+    xdid = _provisional_xdid(mdtext, pubid=pubid)
+    utils.warn("neither Number nor Date for '%s'; assigning provisional xdid %s" % (xd.filename, xdid))
+    return "%s/unshelved/%s" % (publisher or pubid, xdid)
 

--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -131,19 +131,67 @@ def lookup_xdid_override(extsrc, source_filename):
     return _load_overrides().get((extsrc, source_filename))
 
 
+_VARIANT_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+
+
+def mint_variant_xdid(base_xdid, ExternalSource, SourceFilename, in_run_claimed=None):
+    """Mint a stable variant xdid (e.g. 'nys2007-03-27a') for a source that
+    diverges from the canonical claimant of base_xdid.
+
+    Stability across reimports: if a receipt already maps this
+    (ExternalSource, SourceFilename) to a variant of base_xdid, reuse it.
+    Letters are permanent once assigned, so processing-order changes don't
+    reshuffle which source got which letter.
+
+    First-time assignment picks the lowest letter not already claimed in
+    receipts.tsv or in this run (via in_run_claimed, a set/iterable of
+    fully-formed variant xdids written earlier in the same run).
+
+    Returns None if base_xdid has no recognized shelf format or all 26
+    letter slots are taken.
+    """
+    if shelf_path_from_xdid(base_xdid) is None:
+        return None
+
+    base_pattern = re.compile(r'^' + re.escape(base_xdid) + r'[a-z]$')
+
+    for r in metadb.check_already_received(ExternalSource, SourceFilename):
+        if r.xdid and base_pattern.match(r.xdid):
+            return r.xdid
+
+    claimed_letters = set()
+    for r in metadb.variants_of_xdid(base_xdid):
+        claimed_letters.add(r.xdid[-1])
+    if in_run_claimed:
+        for v in in_run_claimed:
+            if base_pattern.match(v):
+                claimed_letters.add(v[-1])
+
+    for letter in _VARIANT_LETTERS:
+        if letter not in claimed_letters:
+            return base_xdid + letter
+    return None
+
+
 def shelf_path_from_xdid(xdid):
     """Derive shelf path (without .xd extension) from a real xdid string.
-    Returns None if the xdid format isn't recognized."""
-    # Date format: <pubid>YYYY-MM-DD
-    m = re.match(r'^([a-z]+)\d{4}-\d{2}-\d{2}$', xdid)
+    Returns None if the xdid format isn't recognized.
+
+    A trailing single-letter suffix marks a variant (same canonical date/number
+    keyed under multiple SourceFilenames that produce divergent .xd content).
+    Variants shelve next to their base on disk: nys2007-03-27a sits in
+    nysun/2007/ alongside nys2007-03-27.
+    """
+    # Date format with optional letter variant: <pubid>YYYY-MM-DD[a-z]
+    m = re.match(r'^([a-z]+)(\d{4})-\d{2}-\d{2}[a-z]?$', xdid)
     if m:
         pubid = m.group(1)
         publ = metadb.xd_publications().get(pubid)
         publisher = publ.PublisherAbbr if publ else pubid
-        year = xdid[len(pubid):len(pubid) + 4]
+        year = m.group(2)
         return "%s/%s/%s" % (publisher, year, xdid)
-    # Number format: <pubid>-NNN
-    m = re.match(r'^([a-z]+)-\d+$', xdid)
+    # Number format with optional letter variant: <pubid>-NNN[a-z]
+    m = re.match(r'^([a-z]+)-\d+[a-z]?$', xdid)
     if m:
         pubid = m.group(1)
         publ = metadb.xd_publications().get(pubid)

--- a/xdfile/metadatabase.py
+++ b/xdfile/metadatabase.py
@@ -2,6 +2,7 @@
 import atexit
 import os.path
 import codecs
+import re
 from collections import namedtuple
 
 from .utils import COLSEP, EOL
@@ -233,11 +234,33 @@ def _receipts_by_xdid():
 
 
 def latest_receipt_for_xdid(xdid):
-    """Return the most recent receipt for a given xdid, or None."""
+    """Return the most recent receipt for a given xdid, or None.
+
+    Doubles as the canonical-claimant rule: receipts are append-only and
+    every state change writes a new row, so the most-recent receipt mapping
+    a SourceFilename to xdid is its current canonical claim. Displacement
+    works because the displaced source's *new* receipt has a different xdid
+    (the variant), so it drops out of this query — leaving the promoted
+    source's new row as the latest for xdid.
+    """
     rows = _receipts_by_xdid().get(xdid, [])
     if not rows:
         return None
     return max(rows, key=lambda r: r.ReceivedTime)
+
+
+def variants_of_xdid(base_xdid):
+    """Return list of receipts whose xdid is a single-letter variant of base_xdid.
+
+    e.g. for base_xdid='nys2007-03-27' returns receipts with xdid in
+    {'nys2007-03-27a', 'nys2007-03-27b', ...} that exist on disk.
+    """
+    pattern = re.compile(r'^' + re.escape(base_xdid) + r'[a-z]$')
+    out = []
+    for xdid, rows in _receipts_by_xdid().items():
+        if pattern.match(xdid):
+            out.extend(rows)
+    return out
 
 
 def xd_sources_row(SourceFilename, ExternalSource, DownloadTime):

--- a/xdfile/tests/test_catalog_provisional.py
+++ b/xdfile/tests/test_catalog_provisional.py
@@ -1,5 +1,9 @@
 """Unit tests for catalog.py provisional xdid helpers."""
 from xdfile import catalog
+from xdfile.xdfile import xdfile as XDFile
+
+
+_MINIMAL_XD = "Title: t\n\n\nA\n\n\nA1. c ~ A\n"
 
 
 def test_is_provisional_real_xdids_negative():
@@ -107,3 +111,50 @@ def test_shelf_path_from_xdid_unrecognized():
     assert catalog.shelf_path_from_xdid("not-an-xdid") is None
     assert catalog.shelf_path_from_xdid("unshelved-a3f9c2b1-foo") is None
     assert catalog.shelf_path_from_xdid("") is None
+
+
+def _make_xd(filename):
+    xd = XDFile(_MINIMAL_XD, filename=filename)
+    return xd
+
+
+def test_deduce_set_seqnum_skips_embedded_digits():
+    # Embedded digits (year fragment, dir index) shouldn't become Number.
+    xd = _make_xd("WAPost/wp92bms.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert not xd.get_header("Number"), "wp92bms (year fragment) should not produce Number"
+    assert not xd.get_header("Date")
+
+
+def test_deduce_set_seqnum_trailing_digits_become_number():
+    xd = _make_xd("foo/up-1234.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert xd.get_header("Number") == "1234"
+
+
+def test_deduce_set_seqnum_trailing_digits_no_separator():
+    xd = _make_xd("other_sources/UP0481.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert xd.get_header("Number") == "481"
+
+
+def test_deduce_set_seqnum_single_digit_number():
+    # Real corpus has small-number puzzles (e.g. bg-1, bg-2); regex must catch.
+    xd = _make_xd("bg-2.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert xd.get_header("Number") == "2"
+
+
+def test_deduce_set_seqnum_trailing_letter_variant():
+    # Optional single-letter variant suffix (e.g. "bg-002a") still extracts Number.
+    xd = _make_xd("bg-002a.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert xd.get_header("Number") == "2"
+
+
+def test_deduce_set_seqnum_date_wins_over_number():
+    # Date heuristic runs first; even if digits are present, Date should be set.
+    xd = _make_xd("nytimes/2015/nyt2015-03-22.xd")
+    catalog.deduce_set_seqnum(xd)
+    assert xd.get_header("Date")
+    assert not xd.get_header("Number")

--- a/xdfile/tests/test_catalog_provisional.py
+++ b/xdfile/tests/test_catalog_provisional.py
@@ -1,0 +1,109 @@
+"""Unit tests for catalog.py provisional xdid helpers."""
+from xdfile import catalog
+
+
+def test_is_provisional_real_xdids_negative():
+    assert not catalog.is_provisional("nyt2015-03-22")
+    assert not catalog.is_provisional("up-481")
+    assert not catalog.is_provisional("")
+    assert not catalog.is_provisional(None)
+
+
+def test_is_provisional_no_pubid_form():
+    assert catalog.is_provisional("unshelved-a3f9c2b1-foo")
+
+
+def test_is_provisional_with_pubid_form():
+    assert catalog.is_provisional("nyt-unshelved-a3f9c2b1-foo")
+
+
+def test_provisional_xdid_no_pubid():
+    xdid = catalog._provisional_xdid("bwh|bwh-2015.tgz|other_sources/foo.puz")
+    assert xdid.startswith("unshelved-")
+    parts = xdid.split("-")
+    assert len(parts[1]) == 8  # hash
+    assert all(c in "0123456789abcdef" for c in parts[1])
+    assert parts[2] == "foo"  # slug
+
+
+def test_provisional_xdid_with_pubid():
+    xdid = catalog._provisional_xdid("bwh|bwh-2015.tgz|other_sources/bridge.puz", pubid="nyt")
+    assert xdid.startswith("nyt-unshelved-")
+    assert xdid.endswith("-bridge")
+
+
+def test_provisional_xdid_deterministic():
+    a = catalog._provisional_xdid("bwh|x.tgz|y.puz")
+    b = catalog._provisional_xdid("bwh|x.tgz|y.puz")
+    assert a == b
+
+
+def test_provisional_xdid_distinct_for_distinct_inputs():
+    a = catalog._provisional_xdid("bwh|x.tgz|foo.puz")
+    b = catalog._provisional_xdid("bwh|x.tgz|bar.puz")
+    c = catalog._provisional_xdid("nyt|x.tgz|foo.puz")
+    assert a != b  # different filename
+    assert a != c  # different ExternalSource
+    assert b != c
+
+
+def test_provisional_slug_strips_specials():
+    assert catalog._provisional_slug("Odd File (v2).puz") == "oddfilev2"
+    assert catalog._provisional_slug("with spaces.puz") == "withspaces"
+    assert catalog._provisional_slug("UPPER123.puz") == "upper123"
+
+
+def test_provisional_slug_dashes_kept():
+    assert catalog._provisional_slug("foo-bar-baz.puz") == "foo-bar-baz"
+
+
+def test_provisional_slug_length_cap():
+    out = catalog._provisional_slug("a" * 100 + ".puz", max_len=10)
+    assert len(out) == 10
+
+
+def test_provisional_slug_empty_fallback():
+    # All-special input strips to nothing -> 'x' fallback
+    assert catalog._provisional_slug("(((.puz") == "x"
+
+
+def test_parse_mdtext_three_parts():
+    assert catalog._parse_mdtext("a|b|c/d") == ("a", "b", "c/d")
+
+
+def test_parse_mdtext_short():
+    assert catalog._parse_mdtext("a|b") == ("a", "b", "")
+    assert catalog._parse_mdtext("") == ("", "", "")
+
+
+def test_provisional_path_no_pubid():
+    xdid = "unshelved-a3f9c2b1-foo"
+    assert catalog.provisional_path(xdid, "bwh") == "unshelved/bwh/" + xdid
+
+
+def test_provisional_path_no_pubid_no_extsrc():
+    xdid = "unshelved-a3f9c2b1-foo"
+    assert catalog.provisional_path(xdid, "") == "unshelved/unknown/" + xdid
+
+
+def test_provisional_path_with_unknown_pubid():
+    # Pubid not in publications.tsv -> publisher falls back to pubid itself.
+    xdid = "fakepub-unshelved-a3f9c2b1-foo"
+    p = catalog.provisional_path(xdid, "bwh")
+    assert p == "fakepub/unshelved/" + xdid
+
+
+def test_shelf_path_from_xdid_date_format():
+    # Pubid not in publications.tsv -> publisher falls back to pubid itself.
+    assert catalog.shelf_path_from_xdid("fakepub2015-03-22") == "fakepub/2015/fakepub2015-03-22"
+
+
+def test_shelf_path_from_xdid_number_format():
+    assert catalog.shelf_path_from_xdid("fakepub-481") == "fakepub/fakepub-481"
+
+
+def test_shelf_path_from_xdid_unrecognized():
+    # Not a recognizable xdid format
+    assert catalog.shelf_path_from_xdid("not-an-xdid") is None
+    assert catalog.shelf_path_from_xdid("unshelved-a3f9c2b1-foo") is None
+    assert catalog.shelf_path_from_xdid("") is None

--- a/xdfile/tests/test_catalog_provisional.py
+++ b/xdfile/tests/test_catalog_provisional.py
@@ -1,6 +1,20 @@
 """Unit tests for catalog.py provisional xdid helpers."""
+from collections import namedtuple
+
 from xdfile import catalog
+from xdfile import metadatabase as metadb
 from xdfile.xdfile import xdfile as XDFile
+
+
+_FakeReceipt = namedtuple("_FakeReceipt", "CaptureTime ReceivedTime ExternalSource InternalSource SourceFilename xdid")
+
+
+def _receipt(ExternalSource, SourceFilename, xdid, ReceivedTime="2016-08-21"):
+    return _FakeReceipt(
+        CaptureTime="", ReceivedTime=ReceivedTime,
+        ExternalSource=ExternalSource, InternalSource="",
+        SourceFilename=SourceFilename, xdid=xdid,
+    )
 
 
 _MINIMAL_XD = "Title: t\n\n\nA\n\n\nA1. c ~ A\n"
@@ -106,11 +120,23 @@ def test_shelf_path_from_xdid_number_format():
     assert catalog.shelf_path_from_xdid("fakepub-481") == "fakepub/fakepub-481"
 
 
+def test_shelf_path_from_xdid_date_variant():
+    # Trailing letter is a variant marker; shelves alongside the canonical date.
+    assert catalog.shelf_path_from_xdid("fakepub2015-03-22a") == "fakepub/2015/fakepub2015-03-22a"
+    assert catalog.shelf_path_from_xdid("fakepub2015-03-22z") == "fakepub/2015/fakepub2015-03-22z"
+
+
+def test_shelf_path_from_xdid_number_variant():
+    assert catalog.shelf_path_from_xdid("fakepub-481a") == "fakepub/fakepub-481a"
+
+
 def test_shelf_path_from_xdid_unrecognized():
     # Not a recognizable xdid format
     assert catalog.shelf_path_from_xdid("not-an-xdid") is None
     assert catalog.shelf_path_from_xdid("unshelved-a3f9c2b1-foo") is None
     assert catalog.shelf_path_from_xdid("") is None
+    # Two-letter variant suffix isn't allowed — only single letter.
+    assert catalog.shelf_path_from_xdid("fakepub2015-03-22ab") is None
 
 
 def _make_xd(filename):
@@ -158,3 +184,120 @@ def test_deduce_set_seqnum_date_wins_over_number():
     catalog.deduce_set_seqnum(xd)
     assert xd.get_header("Date")
     assert not xd.get_header("Number")
+
+
+def _patch_receipts(monkeypatch, by_xdid=None, by_source=None):
+    by_xdid = by_xdid or {}
+    by_source = by_source or {}
+    monkeypatch.setattr(metadb, "_receipts_by_xdid", lambda: by_xdid)
+    monkeypatch.setattr(metadb, "check_already_received",
+                        lambda extsrc, sf: by_source.get((extsrc, sf), []))
+
+
+def test_latest_receipt_for_xdid_returns_max_received_time(monkeypatch):
+    rows = [
+        _receipt("bwh", "NYSun/late.puz",  "nys2007-03-27", ReceivedTime="2018-05-01"),
+        _receipt("bwh", "NYSun/early.puz", "nys2007-03-27", ReceivedTime="2016-08-21"),
+        _receipt("bwh", "NYSun/mid.puz",   "nys2007-03-27", ReceivedTime="2017-01-15"),
+    ]
+    _patch_receipts(monkeypatch, by_xdid={"nys2007-03-27": rows})
+    result = metadb.latest_receipt_for_xdid("nys2007-03-27")
+    assert result.SourceFilename == "NYSun/late.puz"
+
+
+def test_latest_receipt_for_xdid_no_rows(monkeypatch):
+    _patch_receipts(monkeypatch, by_xdid={})
+    assert metadb.latest_receipt_for_xdid("nys2007-03-27") is None
+
+
+def test_latest_receipt_after_displacement_picks_promoted_source(monkeypatch):
+    # Replay state after a --conflict-mode=replace run: A's original 2016 claim
+    # on the canonical xdid is overshadowed by B's 2026 promotion row. A's
+    # demotion row maps A to the variant xdid, so it doesn't appear in the
+    # canonical-xdid query at all.
+    canonical = "nys2007-03-27"
+    variant = "nys2007-03-27a"
+    by_xdid = {
+        canonical: [
+            _receipt("bwh", "A.puz", canonical, ReceivedTime="2016-08-21"),
+            _receipt("bwh", "B.puz", canonical, ReceivedTime="2026-05-06"),
+        ],
+        variant: [
+            _receipt("bwh", "A.puz", variant, ReceivedTime="2026-05-06"),
+        ],
+    }
+    _patch_receipts(monkeypatch, by_xdid=by_xdid)
+    canonical_claimant = metadb.latest_receipt_for_xdid(canonical)
+    variant_claimant = metadb.latest_receipt_for_xdid(variant)
+    assert canonical_claimant.SourceFilename == "B.puz"
+    assert variant_claimant.SourceFilename == "A.puz"
+
+
+def test_variants_of_xdid_matches_letter_suffix(monkeypatch):
+    by_xdid = {
+        "nys2007-03-27":  [_receipt("bwh", "f.puz", "nys2007-03-27")],
+        "nys2007-03-27a": [_receipt("bwh", "g.puz", "nys2007-03-27a")],
+        "nys2007-03-27c": [_receipt("bwh", "h.puz", "nys2007-03-27c")],
+        "nys2007-03-28":  [_receipt("bwh", "i.puz", "nys2007-03-28")],
+        # Not a variant of nys2007-03-27 — different base date.
+        "nys2007-03-28a": [_receipt("bwh", "j.puz", "nys2007-03-28a")],
+    }
+    _patch_receipts(monkeypatch, by_xdid=by_xdid)
+    variants = metadb.variants_of_xdid("nys2007-03-27")
+    xdids = sorted(r.xdid for r in variants)
+    assert xdids == ["nys2007-03-27a", "nys2007-03-27c"]
+
+
+def test_mint_variant_xdid_first_letter(monkeypatch):
+    # No prior receipts for this base -> lowest letter is 'a'.
+    _patch_receipts(monkeypatch, by_xdid={}, by_source={})
+    assert catalog.mint_variant_xdid("nys2007-03-27", "bwh", "x.puz") == "nys2007-03-27a"
+
+
+def test_mint_variant_xdid_skips_claimed_letters(monkeypatch):
+    by_xdid = {
+        "nys2007-03-27a": [_receipt("bwh", "g.puz", "nys2007-03-27a")],
+        "nys2007-03-27b": [_receipt("bwh", "h.puz", "nys2007-03-27b")],
+    }
+    _patch_receipts(monkeypatch, by_xdid=by_xdid)
+    assert catalog.mint_variant_xdid("nys2007-03-27", "bwh", "new.puz") == "nys2007-03-27c"
+
+
+def test_mint_variant_xdid_stability_reuses_prior_assignment(monkeypatch):
+    # SourceFilename already has a receipt for variant 'b' -> reuse it,
+    # even though 'a' is currently free.
+    by_xdid = {
+        "nys2007-03-27b": [_receipt("bwh", "g.puz", "nys2007-03-27b")],
+    }
+    by_source = {
+        ("bwh", "g.puz"): [_receipt("bwh", "g.puz", "nys2007-03-27b")],
+    }
+    _patch_receipts(monkeypatch, by_xdid=by_xdid, by_source=by_source)
+    assert catalog.mint_variant_xdid("nys2007-03-27", "bwh", "g.puz") == "nys2007-03-27b"
+
+
+def test_mint_variant_xdid_in_run_claimed(monkeypatch):
+    # 'a' was minted earlier in this same run (not yet in receipts.tsv).
+    _patch_receipts(monkeypatch, by_xdid={}, by_source={})
+    assert catalog.mint_variant_xdid(
+        "nys2007-03-27", "bwh", "new.puz",
+        in_run_claimed={"nys2007-03-27a"},
+    ) == "nys2007-03-27b"
+
+
+def test_mint_variant_xdid_exhausted(monkeypatch):
+    by_xdid = {"nys2007-03-27" + ch: [_receipt("bwh", ch + ".puz", "nys2007-03-27" + ch)]
+               for ch in "abcdefghijklmnopqrstuvwxyz"}
+    _patch_receipts(monkeypatch, by_xdid=by_xdid)
+    assert catalog.mint_variant_xdid("nys2007-03-27", "bwh", "new.puz") is None
+
+
+def test_mint_variant_xdid_unrecognized_base(monkeypatch):
+    # Base xdid with no shelf format -> nothing to mint.
+    _patch_receipts(monkeypatch)
+    assert catalog.mint_variant_xdid("not-an-xdid", "bwh", "x.puz") is None
+
+
+def test_mint_variant_xdid_number_format(monkeypatch):
+    _patch_receipts(monkeypatch, by_xdid={})
+    assert catalog.mint_variant_xdid("up-481", "bwh", "x.puz") == "up-481a"

--- a/xdfile/utils.py
+++ b/xdfile/utils.py
@@ -5,6 +5,7 @@ import functools
 import stat
 import sys
 import zipfile
+import tarfile
 import io
 import csv
 import string
@@ -260,6 +261,25 @@ def generate_zip_files(data):
         error("generate_zip_files(): %s" % str(e))
 
 
+def generate_tar_files(data):
+    try:
+        tf = tarfile.open(fileobj=io.BytesIO(data), mode='r:*')
+        members = sorted((m for m in tf.getmembers() if m.isfile()), key=lambda m: m.name)
+        for m in members:
+            f = tf.extractfile(m)
+            if f is None:
+                continue
+            yield m.name, f.read(), m.mtime
+    except tarfile.TarError as e:
+        error("generate_tar_files(): %s" % str(e))
+
+
+def _is_tar_path(path):
+    p = path.lower()
+    return p.endswith('.tar') or p.endswith('.tgz') or p.endswith('.tar.gz') \
+        or p.endswith('.tar.bz2') or p.endswith('.tar.xz')
+
+
 # walk all 'paths' recursively and yield (filename, contents) for non-hidden files
 def find_files_with_time(*paths, **kwargs):
     ext = kwargs.get("ext")
@@ -277,6 +297,12 @@ def find_files_with_time(*paths, **kwargs):
                             if ext and not zipfn.endswith(ext):
                                 continue
                             yield fn + ":" + zipfn, zipdata, zipdt
+
+                    elif _is_tar_path(fn):
+                        for tarfn, tardata, tardt in generate_tar_files(open(fullfn, 'rb').read()):
+                            if ext and not tarfn.endswith(ext):
+                                continue
+                            yield fn + ":" + tarfn, tardata, tardt
 
                     elif ext and not fn.endswith(ext):  # only looking for one particular ext, don't log
                         continue
@@ -301,6 +327,18 @@ def find_files_with_time(*paths, **kwargs):
                     zipfn = strip_toplevel(zipfn)
 
                 yield zipfn, zipdata, zipdt
+
+        elif _is_tar_path(path):
+            for tarfn, tardata, tardt in generate_tar_files(open(path, 'rb').read()):
+                if ext and not tarfn.endswith(ext):
+                    continue
+
+                progress(tarfn)
+
+                if should_strip_toplevel:
+                    tarfn = strip_toplevel(tarfn)
+
+                yield tarfn, tardata, tardt
 
         else:
             if ext and not path.endswith(ext):


### PR DESCRIPTION
A handful of related improvements driven by the bwh-2015.tgz re-import work.

`xdfile/utils.py`: support `.tgz/.tar.gz/.tar/.tar.bz2/.tar.xz` inputs in `find_files_with_time`, parallel to the existing `.zip` handling. Lets the importer read directly from a tarball instead of having to unpack it first. Working directly with the original tarball guarantees canonical source filenames.

`xdfile/catalog.py`:
- provisional xdids: stable temp xdids of the form `unshelved-<hash8>-<slug>` (no pubid) or `<pubid>-unshelved-<hash8>-<slug>` (when `pubid` is known, but missing Date/Number), with disk paths under `unshelved/<extsrc>/` or `<publisher>/unshelved/`
- `overrides.tsv` reader: per-file manual (`ExternalSource`, `SourceFilename`) ->
  xdid mapping for cases where filename or metadata inference is wrong/insufficient

`scripts/18-convert2xd.py`:
- `--include/` `--exclude/` `--excludes-file` glob filters on `SourceFilename`: support importing subsets directly from full archive file.
- renamed `--force` to `--overwrite`
- shelf-relocation warning when prev_xdid is real and current headers deduce a different xdid
- provisional-to-real promotion cleanup: deletes the old provisional .xd
- ownership guard: refuse to overwrite a shelf slot claimed by a different (ExternalSource, SourceFilename); `--overwrite`  to override
- append to `receipts.tsv` only when xdid is non-empty AND the state changed from the latest receipt; covers gap-fills, retries, provisional->real promotions; skips no-ops, parse failures, ownership-blocked writes

`xdfile/tests/test_catalog_provisional.py`: unit tests for the provisional xdid helpers and `shelf_path_from_xdid`.