### PR TITLE
puz2xd: strip stray \xc3\x82 mojibake before clean_latin1_utf8_mojibake

### DIFF
--- a/puz2xd-standalone.py
+++ b/puz2xd-standalone.py
@@ -80,6 +80,10 @@ def decode(s):
     # UTF-8 NBSP read as latin-1 -> 'Â\xa0'; then any remaining NBSPs.
     s = s.replace('\xc2\xa0', ' ')
     s = s.replace('\xa0', ' ')
+    # Stray 'Ã\x82' (puz bytes \xc3\x82 read as latin-1) is known mojibake
+    # garbage in this corpus -- not real text. Strip before
+    # clean_latin1_utf8_mojibake, which would otherwise re-decode it as 'Â'.
+    s = s.replace('\xc3\x82', '')
     # \xc3\xa8 UTF-8 (è) misread as latin-1 -> 'Ã¨'. Targeted replacement.
     s = s.replace('Ã¨', 'è')
     # MacRoman left/right curly double quotes.

--- a/xdfile/puz2xd.py
+++ b/xdfile/puz2xd.py
@@ -32,6 +32,12 @@ def decode(s):
     # UTF-8 NBSP read as latin-1 surfaces as 'Â\xa0'; collapse to space.
     s = s.replace('\xc2\xa0', ' ')
     s = s.replace('\xa0', ' ')
+    # Stray 'Ã\x82' (puz bytes \xc3\x82 read as latin-1) is a known mojibake
+    # artifact in this corpus -- not real text. The 2016-era decode() stripped
+    # it explicitly; without that, clean_latin1_utf8_mojibake below would re-
+    # decode it as 'Â' (U+00C2), inserting a literal capital-A-circumflex in
+    # the middle of clue text. Strip before the systematic mojibake pass.
+    s = s.replace('\xc3\x82', '')
     # \xc3\xa8 = UTF-8 byte sequence for U+00E8 (è) misread as latin-1 ('Ã¨').
     # Targeted because real 'Ã¨' is unusual in puzzle text.
     s = s.replace('Ã¨', 'è')

--- a/xdfile/tests/test_puz2xd_decode.py
+++ b/xdfile/tests/test_puz2xd_decode.py
@@ -145,3 +145,16 @@ def test_decode_collapses_nbsp():
     # \xc2\xa0 = UTF-8 NBSP read as latin-1; \xa0 = bare NBSP. Both -> space.
     assert decode("foo\xc2\xa0bar") == "foo bar"
     assert decode("foo\xa0bar") == "foo bar"
+
+
+def test_decode_strips_c3_82_mojibake_artifact():
+    # Bytes \xc3\x82 in the puz file (puzpy reads as 'Ã\x82') aren't real
+    # text -- they're a stray mojibake artifact left over from upstream
+    # encoding round-trips. Without an explicit strip, clean_latin1_utf8_
+    # mojibake re-decodes them as 'Â' (U+00C2), inserting a literal capital
+    # A-circumflex in the middle of clue text.
+    # Regression: gxd/universal/2015/up2015-10-16.xd D10 "Cleo's slayer ~ ASP"
+    # — puz had bytes \xc3\x82 between "Cleo" and "'s", producing "CleoÂ's".
+    assert decode("Cleo\xc3\x82's slayer") == "Cleo's slayer"
+    # Combine with adjacent legit mojibake — strip applies only to \xc3\x82.
+    assert decode("Cafe\xc3\x82 Caf\xc3\xa9") == "Cafe Café"

--- a/xdlint.py
+++ b/xdlint.py
@@ -1724,14 +1724,24 @@ _ORPHAN_QUOTE_TRAILER_RE = re.compile(r'"[\x9c\x9d]')
 @fixer("XD009")
 def _(text):
     """UTF-8 latin-supplement misread as latin-1: 'Ã' + cont-byte (and 'Â'
-    + cont-byte) re-decoded through latin-1 -> UTF-8 round-trip."""
+    + cont-byte) re-decoded through latin-1 -> UTF-8 round-trip.
+
+    Special case: 'Ã\\x82' (puz bytes \\xc3\\x82) is a known stray-mojibake
+    artifact in the corpus -- not real text. Stripped rather than re-decoded,
+    which would produce a literal 'Â' (U+00C2) sitting in the middle of clue
+    text. Mirrors the explicit strip in xdfile/puz2xd.py decode().
+    """
     count = 0
     def repl(m):
         nonlocal count
+        s = m.group(0)
+        if s == '\xc3\x82':
+            count += 1
+            return ''
         try:
-            replacement = m.group(0).encode('latin-1').decode('utf-8')
+            replacement = s.encode('latin-1').decode('utf-8')
         except UnicodeDecodeError:
-            return m.group(0)
+            return s
         count += 1
         return replacement
     return _LATIN1_UTF8_RE.sub(repl, text), count


### PR DESCRIPTION
Pre-rewrite `decode()` had this explicit line:
```
  s = s.replace('\xc3\x82', '')
```

with the comment "Don't know what it this symbol for". The encoding-fix commit 1a4eed97b generalized per-byte cleanups into systematic logic (`clean_latin1_utf8_mojibake`) and dropped this explicit strip. The general logic now matches `\xc3\x82` against the `[\xc2\xc3][\x80-\xbf]` regex, encodes back to latin-1 and decodes as UTF-8, producing 'Â' (U+00C2) -- a literal capital A-circumflex inserted in the middle of clue text. Regression shows up on reimport as e.g. "CleoÂ's slayer" where the corpus had "Cleo's slayer".

Tiny population: only 10 puz files in the entire bwh archive contain this byte sequence (9 in other_sources, 1 in NYTimes). The pre-2016 intent was clearly to treat it as garbage, and there's no real-text context where these two bytes adjacent in a puz file mean anything -- they're upstream encoding-pipeline residue.

`xdfile/puz2xd.py`: explicit `s.replace('\xc3\x82', '')` before `clean_latin1_utf8_mojibake`. Mirrored in `puz2xd-standalone.py` per the "changes to one should be mirrored in the other" CLAUDE.md note.

`xdlint.py`: `XD009` fixer special-cases the same two-codepoint sequence, stripping rather than re-decoding, so corpus files re-linted after import don't reintroduce the 'Â' that the original decode passed through. Keeps the decode/lint parity policy intact.

Tests: new `test_decode_strips_c3_82_mojibake_artifact` in `test_puz2xd_decode.py` covers the regression case from `up2015-10-16.xd` and verifies the strip is local (legit \xc3\xa9 etc. still re-decode).

(Claude wrote this)