### PR TITLE
catalog: anchor pubregex matches to word boundary

### DIFF
--- a/xdfile/catalog.py
+++ b/xdfile/catalog.py
@@ -66,9 +66,11 @@ def find_pubid(rowstr):
 
     Returns None if no match, or if the winning stage produces multiple matches.
     '''
+    # Anchor every pattern to a word boundary so prefix-style entries
+    # (e.g. `ut\d`) don't match mid-token like the "ut1" in "PutOut15".
     explicit = set()
     for r in _load_pubregex():
-        if re.search(r['regex'], rowstr, flags=re.IGNORECASE):
+        if re.search(r'\b' + r['regex'], rowstr, flags=re.IGNORECASE):
             explicit.add(r['pubid'])
 
     if len(explicit) == 1:
@@ -79,7 +81,7 @@ def find_pubid(rowstr):
 
     implicit = set()
     for pubid in metadb.xd_publications().keys():
-        if re.search(r'%s(\d|-)' % re.escape(pubid), rowstr, flags=re.IGNORECASE):
+        if re.search(r'\b%s(\d|-)' % re.escape(pubid), rowstr, flags=re.IGNORECASE):
             implicit.add(pubid)
 
     if len(implicit) == 1:


### PR DESCRIPTION
## Summary

`find_pubid()` in `xdfile/catalog.py` was searching `pubregex.tsv` patterns and the implicit `<pubid>(\d|-)` patterns against the metadata rowstr without anchoring. Prefix-style entries like `ut\d` therefore matched mid-token — e.g. the `ut1` inside `LS060609-PutOut15.puz` — and shelved that file as `usa2006-06-09`.

Fix: prepend `\b` to the regex at search time in both passes. No edits to `gxd/pubregex.tsv`; every existing entry there is a prefix pattern that still matches correctly.

## Test plan

- [x] `pytest xdfile/tests/` — 31 passed
- [x] Spot-check: `re.search(r'\but\d', 'LS060609-PutOut15.puz', re.I)` no longer matches; `re.search(r'\but\d', 'ut090101.puz', re.I)` still matches