### PR TITLE
add xdlint rule to detect cryptics in the corpus

### DIFF
--- a/tests/test_xdlint.py
+++ b/tests/test_xdlint.py
@@ -1008,7 +1008,7 @@ class TestFeatureDetectionRules:
 
     def test_simple_emits_no_feature_findings(self):
         for code in ("XD301", "XD302", "XD303", "XD304", "XD305",
-                     "XD306", "XD307"):
+                     "XD306", "XD307", "XD309"):
             assert run_rule(code, SIMPLE) == [], f"{code} fired on SIMPLE"
 
     def test_xd301_uses_rebus(self):
@@ -1074,6 +1074,85 @@ class TestFeatureDetectionRules:
         )
         f = run_rule("XD307", text)
         assert len(f) == 1
+
+    # XD309: cryptic detection. Lattice grid: 3-row, 5-col with all middle
+    # row blocked. 6 across singletons + 6 down singletons = 12 grid signal.
+    _CRYPTIC_GRID = (
+        "Title: T\nDate: 2024-01-01\n\n\n"
+        "A#B#C\n#####\nD#E#F\n\n\n"
+    )
+    # Dense 5x5 grid with no singletons (5 across slots of length 5, same for
+    # down). Used to isolate the clue-signal path.
+    _DENSE_GRID = (
+        "Title: T\nDate: 2024-01-01\n\n\n"
+        "ABCDE\nFGHIJ\nKLMNO\nPQRST\nUVWXY\n\n\n"
+    )
+
+    def test_xd309_high_confidence_cryptic(self):
+        """Both signals strong: lattice grid + cryptic length annotations."""
+        text = self._CRYPTIC_GRID + (
+            "A1. anagram (1) ~ A\n"
+            "A2. clue body (3,4) ~ B\n"
+            "A3. clue body (5) ~ C\n"
+            "A4. clue body (2) ~ D\n"
+            "A5. clue body (4) ~ E\n"
+            "A6. clue body (6) ~ F\n"
+        )
+        f = run_rule("XD309", text)
+        assert len(f) == 1
+        assert "high" in f[0].message
+        assert "grid_singletons=12" in f[0].message
+
+    def test_xd309_grid_signal_only_review(self):
+        """Lattice grid but no length-annotated clues -> review."""
+        text = self._CRYPTIC_GRID + (
+            "A1. plain clue ~ A\n"
+            "A2. plain clue ~ B\n"
+            "A3. plain clue ~ C\n"
+            "A4. plain clue ~ D\n"
+            "A5. plain clue ~ E\n"
+            "A6. plain clue ~ F\n"
+        )
+        f = run_rule("XD309", text)
+        assert len(f) == 1
+        assert "review" in f[0].message
+
+    def test_xd309_clue_signal_only_review(self):
+        """Regular dense grid + cryptic-style length annotations -> review."""
+        text = self._DENSE_GRID + (
+            "A1. one (5) ~ ABCDE\n"
+            "A6. two (5) ~ FGHIJ\n"
+            "A7. three (5) ~ KLMNO\n"
+            "A8. four (5) ~ PQRST\n"
+            "A9. five (5) ~ UVWXY\n"
+        )
+        f = run_rule("XD309", text)
+        assert len(f) == 1
+        assert "review" in f[0].message
+
+    def test_xd309_no_flag_when_signals_below_threshold(self):
+        """A few singletons or hints below the threshold should not flag."""
+        # 2x2 grid with just one singleton; one length-annotated clue.
+        text = (
+            "Title: T\nDate: 2024-01-01\n\n\n"
+            "A#\n#B\n\n\n"
+            "A1. plain (1) ~ A\n"
+        )
+        assert run_rule("XD309", text) == []
+
+    def test_xd309_year_annotation_not_counted_as_length_hint(self):
+        """Clues ending in '(YYYY)' (publication year etc.) must NOT count
+        as cryptic length hints; the regex caps numbers at 2 digits."""
+        text = self._DENSE_GRID + (
+            "A1. memoir (2010) ~ ABCDE\n"
+            "A6. memoir (1984) ~ FGHIJ\n"
+            "A7. memoir (2018) ~ KLMNO\n"
+            "A8. memoir (2003) ~ PQRST\n"
+            "A9. memoir (1978) ~ UVWXY\n"
+        )
+        # Dense grid -> grid_signal = 0; year annotations -> clue_signal = 0.
+        # No flag.
+        assert run_rule("XD309", text) == []
 
 
 class TestSeverityChanges:

--- a/xdlint.py
+++ b/xdlint.py
@@ -1466,6 +1466,79 @@ def _(ctx):
             break
 
 
+# Cryptic crossword detection (adapted from scripts/91-find-cryptics in
+# alexdej/wip). Two near-orthogonal signals: (1) lattice grids have many
+# 1-cell across/down slots, very rare in American-style puzzles; (2) cryptic
+# clues conventionally end with an answer-length annotation like "(5)" or
+# "(3,4)". Both signals together → high confidence. One alone → suspect.
+# Cryptic length annotations are word-length tallies (1-2 digits, e.g.
+# "(5)" or "(3,4)"). Years like "(2010)" at the end of a clue are NOT
+# cryptic hints; capping at 2 digits filters those out.
+_CRYPTIC_LEN_RE = re.compile(r"\(\d{1,2}(?:[,\s]+\d{1,2})*\)\s*$")
+_CRYPTIC_GRID_THRESHOLD = 5
+_CRYPTIC_CLUE_THRESHOLD = 5
+
+
+def _count_singleton_slots(grid):
+    """Return (across_singletons, down_singletons) where a singleton is a
+    non-block cell with blocks (or edges) on both sides along that axis."""
+    h = len(grid)
+    if h == 0:
+        return 0, 0
+    w = max(len(r.cells) for r in grid)
+
+    def cell(y, x):
+        if y < 0 or y >= h or x < 0 or x >= w:
+            return "#"
+        row = grid[y].cells
+        return row[x] if x < len(row) else "#"
+
+    across = 0
+    for y in range(h):
+        for x in range(w):
+            c = cell(y, x)
+            if c == "#":
+                continue
+            if cell(y, x - 1) == "#" and cell(y, x + 1) == "#":
+                across += 1
+    down = 0
+    for y in range(h):
+        for x in range(w):
+            c = cell(y, x)
+            if c == "#":
+                continue
+            if cell(y - 1, x) == "#" and cell(y + 1, x) == "#":
+                down += 1
+    return across, down
+
+
+@rule("XD309", Severity.INFO, "likely-cryptic")
+def _(ctx):
+    """File looks like a cryptic crossword (lattice grid + length-annotated
+    clues). Emits one finding per file with the confidence and signal counts."""
+    grid = ctx.parsed.grid
+    if not grid:
+        return
+    across, down = _count_singleton_slots(grid)
+    grid_signal = across + down
+    clue_signal = sum(
+        1 for c in ctx.parsed.clues if _CRYPTIC_LEN_RE.search(c.body)
+    )
+    if (grid_signal >= _CRYPTIC_GRID_THRESHOLD
+            and clue_signal >= _CRYPTIC_CLUE_THRESHOLD):
+        confidence = "high"
+    elif (grid_signal >= _CRYPTIC_GRID_THRESHOLD
+          or clue_signal >= _CRYPTIC_CLUE_THRESHOLD):
+        confidence = "review"
+    else:
+        return
+    yield finding(
+        "XD309", Severity.INFO, 1,
+        f"likely cryptic ({confidence}): grid_singletons={grid_signal} "
+        f"(A={across},D={down}), clue_length_hints={clue_signal}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Rules - info
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Idea was to use some heuristics to detect the presence of cryptic crosswords in gxd/. Turns out there aren't any, but since I have the rule I guess I might as well merge it in case it turns out useful some day. :/