### PR TITLE
doc: archive 2016 EC2 notes, fix README requirements, modernize CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,23 @@
-# Contributing to xdfile
+# Contributing to xd
 
-## setting up the environment
+## Setting up the environment
 
-Install dependencies:
+```
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install pytest
+```
 
-        $ pip install puzpy crossword 
-        $ pip install pytest tox flake8
+## Running tests
 
-Setup tox:
+```
+pytest xdfile/tests/
+```
 
-        $ tox setup
+## Validating .xd files
 
-This creates a virtualenv and runs tests against the package. A couple points:
+`xdlint.py` is the authoritative validator for the .xd format (stdlib-only). See the [README](README.md#validating-xd-files) for usage.
 
-* Eventually, **pip install -e dev** will get all dependencies.
-* tox requires MANIFEST.in to locate files to copy into the virtualenv test environments.
-
-## running tests
-
-To execute everything for packaging and testing:
-
-        $ tox
-
-To just run unit tests:
-
-        $ python -m pytest
-
-## code style
+## Code style
 
 The xd project mostly follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
-
-## packaging and setup
-
-Test the setup with a dry run:
-
-        $ python setup.py install -n
-

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ See [`doc/rebus-conventions.md`](doc/rebus-conventions.md) for the rebus / quant
 
 - python 3.7+
 - git
-- markdown (to build website)
+- pandoc (to build website)
 - sqlite (for grid comparison)
 - gcc (to build sqlite plugin)
-- aws-cli (to deploy)
 
 # Running the pipeline
 

--- a/doc/archive/AWS-ec2-2016.md
+++ b/doc/archive/AWS-ec2-2016.md
@@ -1,4 +1,4 @@
-# AWS commands
+# AWS EC2 commands (archived 2026-06 — 2016-era pipeline, instance long gone)
 
 ## Extend root volume of instance
 1) Stop instance


### PR DESCRIPTION
Cleanup pass removing stale/false information from the primary docs:

- **AWS.md → doc/archive/AWS-ec2-2016.md** — EC2 volume-resize notes and the `andjelx/xd` staging-branch bootstrap are from the 2016 pipeline; archived with a header so nobody mistakes them for current ops.
- **README.md** — requirements corrected: the site is built with pandoc (not the `markdown` package), and aws-cli is no longer needed to deploy (Netlify).
- **CONTRIBUTING.md** — replaced the stale tox/setup.py instructions with the venv + requirements.txt + pytest flow that actually works today.

[this PR written by Claude Fable 5 at @saulpw's request]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
