### PR TITLE
ci: authenticate gxd clones via deploy token (gxd now private)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,27 @@ jobs:
             gxd-
 
       - name: Clone or update gxd
-        run: make setup-gxd
+        # credential helper: keeps the token out of cached gxd/.git/config
+        env:
+          GXD_USER: ${{ secrets.GXD_DEPLOY_USER }}
+          GXD_TOKEN: ${{ secrets.GXD_DEPLOY_TOKEN }}
+        run: |
+          if [ -n "$GXD_TOKEN" ]; then
+            git config --global credential.helper '!f() { echo "username=$GXD_USER"; echo "password=$GXD_TOKEN"; }; f'
+            make setup-gxd
+          elif [ -d gxd ]; then
+            echo "::notice::no gxd deploy token (fork PR?); analyzing cached gxd as-is"
+          else
+            echo "::warning::no gxd deploy token and no cached gxd; skipping analyze"
+            echo "SKIP_ANALYZE=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Install Python deps
+        if: env.SKIP_ANALYZE != '1'
         run: pip install -r requirements.txt
 
       - name: Run make analyze
+        if: env.SKIP_ANALYZE != '1'
         run: make analyze
 
       - name: Upload artifacts

--- a/.github/workflows/nightly-download.yml
+++ b/.github/workflows/nightly-download.yml
@@ -57,7 +57,12 @@ jobs:
         # checks out only the root TSVs (publications.tsv, receipts.tsv, etc.)
         # which is all the downloader reads; new .xd files are written into
         # subdirs and picked up later via `git add --sparse`.
+        # credential helper: gxd is private; token stays out of .git/config
+        env:
+          GXD_USER: ${{ secrets.GXD_DEPLOY_USER }}
+          GXD_TOKEN: ${{ secrets.GXD_DEPLOY_TOKEN }}
         run: |
+          git config --global credential.helper '!f() { echo "username=$GXD_USER"; echo "password=$GXD_TOKEN"; }; f'
           git clone --filter=blob:none --depth=1 --no-checkout https://gitlab.com/rabidrat/gxd.git gxd
           (cd gxd && git sparse-checkout init --cone && git checkout HEAD)
 


### PR DESCRIPTION
Two anonymous `https://gitlab.com/rabidrat/gxd.git` clones in CI are broken:

- **nightly-download**: the sparse clone now authenticates via a GitLab deploy token supplied through a git credential helper.
- **ci/analyze**: `make setup-gxd` runs with the same helper when the token secret is present; on fork PRs (no secrets) it falls back to the weekly-cached gxd as-is, or skips the analyze steps with a warning if there's no cache.

The credential-helper approach (rather than embedding the token in the clone URL) keeps the token out of `gxd/.git/config` — important for the analyze job because that directory is stored in the Actions cache, which fork PRs can restore.

**Requires two new repo secrets before merge** (Settings → Secrets and variables → Actions):
- `GXD_DEPLOY_USER` / `GXD_DEPLOY_TOKEN` — from a GitLab deploy token on rabidrat/gxd (Settings → Repository → Deploy tokens, scope `read_repository`).

Until this merges, tonight's nightly-download run and the next analyze job will fail on the clone step.

[this PR written by Claude Fable 5 at @saulpw's request]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
