### PR TITLE
fix: clean_author crash on empty author (unbreaks make analyze)

### DIFF
--- a/scripts/21-clean-metadata.py
+++ b/scripts/21-clean-metadata.py
@@ -51,7 +51,7 @@ def clean_author(author, editor):
             while author.lower().startswith("by "):
                 author = author[3:]
 
-            while author[-1] in ",.":
+            while author and author[-1] in ",.":
                 author = author[:-1]
         else:
             author = ""
@@ -64,7 +64,7 @@ def clean_author(author, editor):
         while editor.lower().startswith("by "):
             editor = editor[3:]
 
-        while editor[-1] in ",.":
+        while editor and editor[-1] in ",.":
             editor = editor[:-1]
 
     author = author.strip()


### PR DESCRIPTION
`make analyze` has been crashing since 2026-05-11: `gxd/nysun/2008/nys2008-04-04.xd` (from the NYSun bwh reimport) carries `Author: by / Edited by Peter Gordon (puzzleeditor@nysun.com)`, which `clean_author()` strips to an empty string before indexing `author[-1]`. Guarded both that site and the identical latent one for `editor`.

Verified: the crashing header now cleans to `('', 'Peter Gordon (puzzleeditor@nysun.com)')`; normal parses unchanged (`'By Jane Doe, edited by Will Shortz'` → `('Jane Doe', 'Will Shortz')`).

This is also why PR #130's `analyze` check is red — that failure predates the gxd privatization and is unrelated to the PR's own changes; after this merges, a rebase of #130 should go green.

[this PR written by Claude Fable 5 at @saulpw's request]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
