### PR TITLE
doc: spec clarification — markup is clue-text only (#73)

### DIFF
--- a/doc/xd-format.md
+++ b/doc/xd-format.md
@@ -148,6 +148,10 @@ Minimal markup is available.  An example clue line:
 
     A51. {/Italic/}, {*bold*}, {_underscore_}, or {-strike-thru-} ~ MARKUP
 
+Markup is available only in clue text.  Headers and notes are plain text;
+markup syntax appearing in them is not interpreted.  [The markup represents
+the rendered form, as it appeared in the original medium.]
+
 The clue is separated from the answer by a tilde with spaces on both sides (' ~ ').
 
 The full answer should be provided, including rebus expansion.  [This makes clue/answer lines independently useful.]


### PR DESCRIPTION
Codifies the answer already given in #73: markup is available only in clue text; headers and notes are plain text and markup syntax appearing in them is not interpreted. Wording follows @saulpw's comment on the issue ("The markup is intended to represent the rendered form… Metadata does not use markup").

Closes #73.

[this PR written by Claude Fable 5 at @saulpw's request]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
