### PR TITLE
make setup clones the xdformat repo like gxd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ xd*egg*
 build/
 wwwroot/
 gxd/
+xdformat/
 pub/
 tags
 Session.vim

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GXD_GIT=https://gitlab.com/rabidrat/gxd.git
 GXD_DIR=gxd
 SRC_GIT=git@github.com:saulpw/gxd-sources
 SRC_DIR=gxd-sources
+XDFORMAT_GIT=https://github.com/century-arcade/xdformat.git
+XDFORMAT_DIR=xdformat
 WWW_DIR=wwwroot
 PUB_DIR=pub
 NOW=$(shell date +"%Y%m%d-%H%M%S")
@@ -23,14 +25,18 @@ netlify: setup-gxd analyze website
 
 deps:
 	pip install --upgrade -r requirements.txt
+	[ -d ${XDFORMAT_DIR} ] && pip install -e ${XDFORMAT_DIR} || true
 
-setup: setup-gxd setup-src
+setup: setup-gxd setup-src setup-xdformat
 
 setup-gxd:
 	[ ! -d ${GXD_DIR} ] && git clone ${GXD_GIT} ${GXD_DIR} || (cd ${GXD_DIR} && git pull)
 
 setup-src:
 	[ ! -d ${SRC_DIR} ] && git clone ${SRC_GIT} ${SRC_DIR} || (cd ${SRC_DIR} && git pull)
+
+setup-xdformat:
+	[ ! -d ${XDFORMAT_DIR} ] && git clone ${XDFORMAT_GIT} ${XDFORMAT_DIR} || (cd ${XDFORMAT_DIR} && git pull)
 
 import:
 	scripts/11-download-puzzles.py -o ${WWWZIP}


### PR DESCRIPTION
The .xd spec and reference parser/converters now live in [century-arcade/xdformat](https://github.com/century-arcade/xdformat).  This wires that repo into the pipeline's existing setup pattern, same as gxd:

- `make setup` / `make setup-xdformat` clones it into `./xdformat` (clone-or-pull), gitignored
- `make deps` editable-installs it when the clone is present, so `import xdformat` works in the venv

Note the editable install (or adding `./xdformat` to PYTHONPATH) is what makes `import xdformat` resolve; the clone directory itself is the repo root, not the package.

The pipeline doesn't import from it yet -- that adoption (replacing the core of `xdfile/xdfile.py`) is a separate change.

[this PR prepared by Claude Fable 5 for @saulpw]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
